### PR TITLE
Prepare for release v2021.09.27

### DIFF
--- a/docs/CHANGELOG-v2021.09.27.md
+++ b/docs/CHANGELOG-v2021.09.27.md
@@ -1,0 +1,105 @@
+---
+title: Changelog | KubeVault
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubevault-v2021.09.27
+    name: Changelog-v2021.09.27
+    parent: welcome
+    weight: 20210927
+product_name: kubevault
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2021.09.27/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2021.09.27/
+---
+
+# KubeVault v2021.09.27 (2021-09-27)
+
+
+## [kubevault/apimachinery](https://github.com/kubevault/apimachinery)
+
+### [v0.5.0](https://github.com/kubevault/apimachinery/releases/tag/v0.5.0)
+
+- [8dc3a9f4](https://github.com/kubevault/apimachinery/commit/8dc3a9f4) Add support for SecretRoleBinding CRD (#31)
+- [d97bec7d](https://github.com/kubevault/apimachinery/commit/d97bec7d) Update SecretEgnine helper methods (#30)
+- [98e1db0b](https://github.com/kubevault/apimachinery/commit/98e1db0b) Log warning if Community License is used with non-demo namespace (#29)
+- [d2e0997d](https://github.com/kubevault/apimachinery/commit/d2e0997d) Redesign secret engine crds for self-service mode (#26)
+- [7e6e3086](https://github.com/kubevault/apimachinery/commit/7e6e3086) Update repository config (#27)
+- [34f98762](https://github.com/kubevault/apimachinery/commit/34f98762) Update dependencies (#25)
+- [2deacced](https://github.com/kubevault/apimachinery/commit/2deacced) Update dependencies (#24)
+- [19bbdbb1](https://github.com/kubevault/apimachinery/commit/19bbdbb1) Update dependencies (#23)
+- [9d6b8fcd](https://github.com/kubevault/apimachinery/commit/9d6b8fcd) Update dependencies (#22)
+- [13c9a6d4](https://github.com/kubevault/apimachinery/commit/13c9a6d4) Update repository config (#21)
+- [4dfb3d8d](https://github.com/kubevault/apimachinery/commit/4dfb3d8d) Update repository config (#20)
+
+
+
+## [kubevault/cli](https://github.com/kubevault/cli)
+
+### [v0.5.0](https://github.com/kubevault/cli/releases/tag/v0.5.0)
+
+- [1ed8475](https://github.com/kubevault/cli/commit/1ed8475) Prepare for release v0.5.0 (#128)
+- [d2c65bb](https://github.com/kubevault/cli/commit/d2c65bb) Add support for SecretAccessRequest approval or denial (#125)
+- [317a8b4](https://github.com/kubevault/cli/commit/317a8b4) Update dependencies (#126)
+- [d652e30](https://github.com/kubevault/cli/commit/d652e30) Update dependencies (#124)
+- [65ea792](https://github.com/kubevault/cli/commit/65ea792) Update repository config (#123)
+- [a92fa68](https://github.com/kubevault/cli/commit/a92fa68) Update dependencies (#122)
+- [ee676a6](https://github.com/kubevault/cli/commit/ee676a6) Update dependencies (#121)
+- [12a46f3](https://github.com/kubevault/cli/commit/12a46f3) Update dependencies (#120)
+- [d9bd71a](https://github.com/kubevault/cli/commit/d9bd71a) Update dependencies (#119)
+
+
+
+## [kubevault/installer](https://github.com/kubevault/installer)
+
+### [v2021.09.27](https://github.com/kubevault/installer/releases/tag/v2021.09.27)
+
+- [aeb3345](https://github.com/kubevault/installer/commit/aeb3345) Prepare for release v2021.09.27 (#130)
+- [ffe303a](https://github.com/kubevault/installer/commit/ffe303a) Add support for Vault v1.8.2 (#129)
+- [4f5bff4](https://github.com/kubevault/installer/commit/4f5bff4) Redesign secret engine crds for self-service mode (#127)
+- [9d0296f](https://github.com/kubevault/installer/commit/9d0296f) Log warning if Community License is used with non-demo namespace (#128)
+- [c47f4d3](https://github.com/kubevault/installer/commit/c47f4d3) Update dependencies (#126)
+- [f6511e7](https://github.com/kubevault/installer/commit/f6511e7) Update repository config (#125)
+- [3e1b217](https://github.com/kubevault/installer/commit/3e1b217) Update dependencies (#124)
+- [fdfceb0](https://github.com/kubevault/installer/commit/fdfceb0) Update dependencies (#123)
+- [2c428d6](https://github.com/kubevault/installer/commit/2c428d6) Update dependencies (#122)
+- [dfaa322](https://github.com/kubevault/installer/commit/dfaa322) Update repository config (#121)
+- [9dfd255](https://github.com/kubevault/installer/commit/9dfd255) Update repository config (#120)
+
+
+
+## [kubevault/operator](https://github.com/kubevault/operator)
+
+### [v0.5.0](https://github.com/kubevault/operator/releases/tag/v0.5.0)
+
+- [1217e228](https://github.com/kubevault/operator/commit/1217e228) Prepare for release v0.5.0 (#24)
+- [f4c86dfb](https://github.com/kubevault/operator/commit/f4c86dfb) Add support for SecretRoleBinding controller (#23)
+- [58b39012](https://github.com/kubevault/operator/commit/58b39012) Redesign secret engine controllers for self-service mode (#19)
+- [7895759b](https://github.com/kubevault/operator/commit/7895759b) Update dependencies (#20)
+- [a70cfbc5](https://github.com/kubevault/operator/commit/a70cfbc5) Update repository config (#17)
+- [1ec90fe0](https://github.com/kubevault/operator/commit/1ec90fe0) Update dependencies (#18)
+- [f244a0b6](https://github.com/kubevault/operator/commit/f244a0b6) Update dependencies (#16)
+- [a1a8f5d7](https://github.com/kubevault/operator/commit/a1a8f5d7) Restrict to demo namespace for Community Edition (#15)
+- [c48266d8](https://github.com/kubevault/operator/commit/c48266d8) Update repository config (#14)
+- [930f0245](https://github.com/kubevault/operator/commit/930f0245) Update repository config (#13)
+- [ddd838a2](https://github.com/kubevault/operator/commit/ddd838a2) Update repository config (#11)
+
+
+
+## [kubevault/unsealer](https://github.com/kubevault/unsealer)
+
+### [v0.5.0](https://github.com/kubevault/unsealer/releases/tag/v0.5.0)
+
+- [8bcfdf58](https://github.com/kubevault/unsealer/commit/8bcfdf58) Log warning if Community License is used with non-demo namespace (#105)
+- [e6c69d86](https://github.com/kubevault/unsealer/commit/e6c69d86) Update dependencies (#104)
+- [a27f954a](https://github.com/kubevault/unsealer/commit/a27f954a) Update repository config (#103)
+- [1e2c9f1f](https://github.com/kubevault/unsealer/commit/1e2c9f1f) Update dependencies (#102)
+- [694b1f39](https://github.com/kubevault/unsealer/commit/694b1f39) Update dependencies (#101)
+- [7448e6b3](https://github.com/kubevault/unsealer/commit/7448e6b3) Update dependencies (#100)
+- [17da6e49](https://github.com/kubevault/unsealer/commit/17da6e49) Update repository config (#99)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2021.09.27
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/21
Signed-off-by: 1gtm <1gtm@appscode.com>