### PR TITLE
Prepare for release v2021.10.11

### DIFF
--- a/docs/CHANGELOG-v2021.10.11.md
+++ b/docs/CHANGELOG-v2021.10.11.md
@@ -1,0 +1,85 @@
+---
+title: Changelog | KubeVault
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubevault-v2021.10.11
+    name: Changelog-v2021.10.11
+    parent: welcome
+    weight: 20211011
+product_name: kubevault
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2021.10.11/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2021.10.11/
+---
+
+# KubeVault v2021.10.11 (2021-10-09)
+
+
+## [kubevault/apimachinery](https://github.com/kubevault/apimachinery)
+
+### [v0.5.1](https://github.com/kubevault/apimachinery/releases/tag/v0.5.1)
+
+- [311cc741](https://github.com/kubevault/apimachinery/commit/311cc741) Fix jwt-go security vulnerability (#36)
+- [6857c738](https://github.com/kubevault/apimachinery/commit/6857c738) Fix jwt-go security vulnerability (#35)
+- [90b49fc8](https://github.com/kubevault/apimachinery/commit/90b49fc8) Update dependencies to publish SiteInfo (#34)
+- [11f1fc54](https://github.com/kubevault/apimachinery/commit/11f1fc54) Update dependencies to publish SiteInfo (#33)
+- [3f0dfa49](https://github.com/kubevault/apimachinery/commit/3f0dfa49) Update repository config (#32)
+
+
+
+## [kubevault/cli](https://github.com/kubevault/cli)
+
+### [v0.5.1](https://github.com/kubevault/cli/releases/tag/v0.5.1)
+
+- [5b920e6](https://github.com/kubevault/cli/commit/5b920e6) Prepare for release v0.5.1 (#135)
+- [fc8b65e](https://github.com/kubevault/cli/commit/fc8b65e) Fix jwt-go security vulnerability (#133)
+- [cf732f0](https://github.com/kubevault/cli/commit/cf732f0) Fix jwt-go security vulnerability (#132)
+- [235e696](https://github.com/kubevault/cli/commit/235e696) Use nats.go v1.13.0 (#131)
+- [ef9d509](https://github.com/kubevault/cli/commit/ef9d509) Update dependencies to publish SiteInfo (#130)
+- [161aab3](https://github.com/kubevault/cli/commit/161aab3) Update dependencies to publish SiteInfo (#129)
+
+
+
+## [kubevault/installer](https://github.com/kubevault/installer)
+
+### [v2021.10.11](https://github.com/kubevault/installer/releases/tag/v2021.10.11)
+
+- [55910e0](https://github.com/kubevault/installer/commit/55910e0) Prepare for release v2021.10.11 (#137)
+- [12f8428](https://github.com/kubevault/installer/commit/12f8428) Add vault 0.11.5 to catalog (#136)
+- [b80479f](https://github.com/kubevault/installer/commit/b80479f) Use kubevault/vault-exporter:v0.1.1
+- [91bbf45](https://github.com/kubevault/installer/commit/91bbf45) Fix jwt-go security vulnerability (#135)
+- [fa92ac0](https://github.com/kubevault/installer/commit/fa92ac0) Fix jwt-go security vulnerability (#134)
+- [b1688c6](https://github.com/kubevault/installer/commit/b1688c6) Add SiteInfo publisher permission
+- [1ac171c](https://github.com/kubevault/installer/commit/1ac171c) Update dependencies to publish SiteInfo (#133)
+- [4dd5e18](https://github.com/kubevault/installer/commit/4dd5e18) Add kubevault-metrics chart (#132)
+- [275c39d](https://github.com/kubevault/installer/commit/275c39d) Update repository config (#131)
+
+
+
+## [kubevault/operator](https://github.com/kubevault/operator)
+
+### [v0.5.1](https://github.com/kubevault/operator/releases/tag/v0.5.1)
+
+- [2d051c00](https://github.com/kubevault/operator/commit/2d051c00) Prepare for release v0.5.1 (#29)
+- [288a34b1](https://github.com/kubevault/operator/commit/288a34b1) Fix jwt-go security vulnerability (#28)
+- [afbd65b7](https://github.com/kubevault/operator/commit/afbd65b7) Use nats.go v1.13.0 (#27)
+- [8d808837](https://github.com/kubevault/operator/commit/8d808837) Setup SiteInfo publisher (#26)
+- [4fa90b65](https://github.com/kubevault/operator/commit/4fa90b65) Update dependencies to publish SiteInfo (#25)
+
+
+
+## [kubevault/unsealer](https://github.com/kubevault/unsealer)
+
+### [v0.5.1](https://github.com/kubevault/unsealer/releases/tag/v0.5.1)
+
+- [63a431ab](https://github.com/kubevault/unsealer/commit/63a431ab) Fix jwt-go security vulnerability (#109)
+- [2449ab5d](https://github.com/kubevault/unsealer/commit/2449ab5d) Fix jwt-go security vulnerability (#108)
+- [ae44d44a](https://github.com/kubevault/unsealer/commit/ae44d44a) Update dependencies to publish SiteInfo (#107)
+- [e310123c](https://github.com/kubevault/unsealer/commit/e310123c) Update repository config (#106)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2021.10.11
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/22
Signed-off-by: 1gtm <1gtm@appscode.com>