### PR TITLE
Prepare for release v2022.01.11

### DIFF
--- a/docs/CHANGELOG-v2022.01.11.md
+++ b/docs/CHANGELOG-v2022.01.11.md
@@ -1,0 +1,91 @@
+---
+title: Changelog | KubeVault
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubevault-v2022.01.11
+    name: Changelog-v2022.01.11
+    parent: welcome
+    weight: 20220111
+product_name: kubevault
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2022.01.11/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2022.01.11/
+---
+
+# KubeVault v2022.01.11 (2022-01-11)
+
+
+## [kubevault/apimachinery](https://github.com/kubevault/apimachinery)
+
+### [v0.6.0](https://github.com/kubevault/apimachinery/releases/tag/v0.6.0)
+
+- [2fa206cc](https://github.com/kubevault/apimachinery/commit/2fa206cc) Add support for clusterID and sAccessReq phase (#39)
+- [51ba1dca](https://github.com/kubevault/apimachinery/commit/51ba1dca) Update repository config (#42)
+- [9de92d2a](https://github.com/kubevault/apimachinery/commit/9de92d2a) Update Makefile for controller-tools@v0.7.0
+- [3889ec70](https://github.com/kubevault/apimachinery/commit/3889ec70) Update repository config (#41)
+- [2a9d350c](https://github.com/kubevault/apimachinery/commit/2a9d350c) Update dependencies (#40)
+- [3aba09bb](https://github.com/kubevault/apimachinery/commit/3aba09bb) Fix satori/go.uuid security vulnerability (#37)
+
+
+
+## [kubevault/cli](https://github.com/kubevault/cli)
+
+### [v0.6.0](https://github.com/kubevault/cli/releases/tag/v0.6.0)
+
+- [ba4befc](https://github.com/kubevault/cli/commit/ba4befc) Prepare for release v0.6.0 (#140)
+- [8e0a33b](https://github.com/kubevault/cli/commit/8e0a33b) Add support for --vault-ca-cert-path flag (#139)
+- [0117b31](https://github.com/kubevault/cli/commit/0117b31) Add support for Generate, Revoke command (#138)
+- [6214e4c](https://github.com/kubevault/cli/commit/6214e4c) Add support for get-root-token command (#134)
+- [9781501](https://github.com/kubevault/cli/commit/9781501) Update dependencies (#137)
+- [70743de](https://github.com/kubevault/cli/commit/70743de) Fix satori/go.uuid security vulnerability (#136)
+
+
+
+## [kubevault/installer](https://github.com/kubevault/installer)
+
+### [v2022.01.11](https://github.com/kubevault/installer/releases/tag/v2022.01.11)
+
+- [d8ff86b](https://github.com/kubevault/installer/commit/d8ff86b) Prepare for release v2022.01.11 (#144)
+- [5370acd](https://github.com/kubevault/installer/commit/5370acd) Add support for vault:1.9.2 (#143)
+- [ff98bf5](https://github.com/kubevault/installer/commit/ff98bf5) Update repository config (#142)
+- [d5b4bb3](https://github.com/kubevault/installer/commit/d5b4bb3) Add permissions for cert-manager CRs (#141)
+- [57e4d3c](https://github.com/kubevault/installer/commit/57e4d3c) Update repository config (#140)
+- [90b3051](https://github.com/kubevault/installer/commit/90b3051) Update dependencies (#139)
+- [665e185](https://github.com/kubevault/installer/commit/665e185) Fix satori/go.uuid security vulnerability (#138)
+
+
+
+## [kubevault/operator](https://github.com/kubevault/operator)
+
+### [v0.6.0](https://github.com/kubevault/operator/releases/tag/v0.6.0)
+
+- [24359467](https://github.com/kubevault/operator/commit/24359467) Prepare for release v0.6.0 (#42)
+- [b7ebc457](https://github.com/kubevault/operator/commit/b7ebc457) Reworks on operator codebase (#37)
+- [b8121081](https://github.com/kubevault/operator/commit/b8121081) Run trivy scanner (#41)
+- [cc00d749](https://github.com/kubevault/operator/commit/cc00d749) Update repository config (#38)
+- [18307b26](https://github.com/kubevault/operator/commit/18307b26) Remove repository directories before cloning them in CI (#40)
+- [ad2a4d1a](https://github.com/kubevault/operator/commit/ad2a4d1a) Delete existing cluster in CI
+- [6e25e142](https://github.com/kubevault/operator/commit/6e25e142) Always run e2e tests (#39)
+- [3bd270c6](https://github.com/kubevault/operator/commit/3bd270c6) Update repository config (#34)
+- [ccf31742](https://github.com/kubevault/operator/commit/ccf31742) Remove global variable for preconditions (#33)
+- [4497bf40](https://github.com/kubevault/operator/commit/4497bf40) Update dependencies (#31)
+- [37b6030a](https://github.com/kubevault/operator/commit/37b6030a) Fix satori/go.uuid security vulnerability (#30)
+
+
+
+## [kubevault/unsealer](https://github.com/kubevault/unsealer)
+
+### [v0.6.0](https://github.com/kubevault/unsealer/releases/tag/v0.6.0)
+
+- [e4382c74](https://github.com/kubevault/unsealer/commit/e4382c74) Add cluster-name flag (#114)
+- [e4a7e133](https://github.com/kubevault/unsealer/commit/e4a7e133) Fix unseal keys conflict (#113)
+- [b04cc1a6](https://github.com/kubevault/unsealer/commit/b04cc1a6) Update repository config (#112)
+- [e0f4000b](https://github.com/kubevault/unsealer/commit/e0f4000b) Update dependencies (#111)
+- [629984be](https://github.com/kubevault/unsealer/commit/629984be) Fix satori/go.uuid security vulnerability (#110)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2022.01.11
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/24
Signed-off-by: 1gtm <1gtm@appscode.com>