### PR TITLE
Prepare for release v2022.02.22

### DIFF
--- a/docs/CHANGELOG-v2022.02.22.md
+++ b/docs/CHANGELOG-v2022.02.22.md
@@ -1,0 +1,81 @@
+---
+title: Changelog | KubeVault
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubevault-v2022.02.22
+    name: Changelog-v2022.02.22
+    parent: welcome
+    weight: 20220222
+product_name: kubevault
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2022.02.22/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2022.02.22/
+---
+
+# KubeVault v2022.02.22 (2022-02-18)
+
+
+## [kubevault/apimachinery](https://github.com/kubevault/apimachinery)
+
+### [v0.7.0](https://github.com/kubevault/apimachinery/releases/tag/v0.7.0)
+
+- [1831b006](https://github.com/kubevault/apimachinery/commit/1831b006) Cancel concurrent CI runs for same pr/commit (#46)
+- [29e4aefe](https://github.com/kubevault/apimachinery/commit/29e4aefe) Update SiteInfo (#45)
+- [6125f9ff](https://github.com/kubevault/apimachinery/commit/6125f9ff) Publish GenericResource (#44)
+- [a2ece4cc](https://github.com/kubevault/apimachinery/commit/a2ece4cc) Update repository config (#43)
+
+
+
+## [kubevault/cli](https://github.com/kubevault/cli)
+
+### [v0.7.0](https://github.com/kubevault/cli/releases/tag/v0.7.0)
+
+- [53c42c4](https://github.com/kubevault/cli/commit/53c42c4) Prepare for release v0.7.0 (#147)
+- [d9b7e37](https://github.com/kubevault/cli/commit/d9b7e37) Cancel concurrent CI runs for same pr/commit (#146)
+- [4a36f36](https://github.com/kubevault/cli/commit/4a36f36) Update UID generation for GenericResource (#145)
+- [5b3984e](https://github.com/kubevault/cli/commit/5b3984e) Update SiteInfo (#144)
+- [cfe2193](https://github.com/kubevault/cli/commit/cfe2193) Publish GenericResource (#143)
+- [796b9b6](https://github.com/kubevault/cli/commit/796b9b6) Release cli for darwin/arm64 (#142)
+- [af8810e](https://github.com/kubevault/cli/commit/af8810e) Add get, set, delete, and list methods for root-token & unseal-keys (#141)
+
+
+
+## [kubevault/installer](https://github.com/kubevault/installer)
+
+### [v2022.02.22](https://github.com/kubevault/installer/releases/tag/v2022.02.22)
+
+- [d2d0af7](https://github.com/kubevault/installer/commit/d2d0af7) Prepare for release v2022.02.22 (#151)
+- [51e1f6c](https://github.com/kubevault/installer/commit/51e1f6c) Cancel concurrent CI runs for same pr/commit (#150)
+- [78c5444](https://github.com/kubevault/installer/commit/78c5444) Update repository config (#149)
+- [10a50a5](https://github.com/kubevault/installer/commit/10a50a5) Use well-known os label (#148)
+- [642e53e](https://github.com/kubevault/installer/commit/642e53e) Publish GenericResource (#147)
+- [5b68f85](https://github.com/kubevault/installer/commit/5b68f85) Update repository config (#146)
+- [53a096a](https://github.com/kubevault/installer/commit/53a096a) Add permission to list namespace (#145)
+
+
+
+## [kubevault/operator](https://github.com/kubevault/operator)
+
+### [v0.7.0](https://github.com/kubevault/operator/releases/tag/v0.7.0)
+
+- [638a2c60](https://github.com/kubevault/operator/commit/638a2c60) Prepare for release v0.7.0 (#49)
+- [705a39ea](https://github.com/kubevault/operator/commit/705a39ea) Update UID generation for GenericResource (#48)
+- [f7bf562f](https://github.com/kubevault/operator/commit/f7bf562f) Update SiteInfo (#47)
+- [4cc99f5a](https://github.com/kubevault/operator/commit/4cc99f5a) Publish GenericResource (#46)
+- [f1d9dee4](https://github.com/kubevault/operator/commit/f1d9dee4) Update repository config (#44)
+- [6bc100d3](https://github.com/kubevault/operator/commit/6bc100d3) Fix matchlabels ns list bug (#45)
+
+
+
+## [kubevault/unsealer](https://github.com/kubevault/unsealer)
+
+### [v0.7.0](https://github.com/kubevault/unsealer/releases/tag/v0.7.0)
+
+- [d1e13106](https://github.com/kubevault/unsealer/commit/d1e13106) Publish GenericResource (#115)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2022.02.22
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/26
Signed-off-by: 1gtm <1gtm@appscode.com>