### PR TITLE
Prepare for release v2022.09.05-rc.0

### DIFF
--- a/docs/CHANGELOG-v2022.09.05-rc.0.md
+++ b/docs/CHANGELOG-v2022.09.05-rc.0.md
@@ -1,0 +1,68 @@
+---
+title: Changelog | KubeVault
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubevault-v2022.09.05-rc.0
+    name: Changelog-v2022.09.05-rc.0
+    parent: welcome
+    weight: 20220905
+product_name: kubevault
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2022.09.05-rc.0/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2022.09.05-rc.0/
+---
+
+# KubeVault v2022.09.05-rc.0 (2022-09-06)
+
+
+## [kubevault/apimachinery](https://github.com/kubevault/apimachinery)
+
+### [v0.9.0-rc.0](https://github.com/kubevault/apimachinery/releases/tag/v0.9.0-rc.0)
+
+- [857a5c01](https://github.com/kubevault/apimachinery/commit/857a5c01) Add vault ops-request API (#61)
+
+
+
+## [kubevault/cli](https://github.com/kubevault/cli)
+
+### [v0.9.0-rc.0](https://github.com/kubevault/cli/releases/tag/v0.9.0-rc.0)
+
+- [a80515e1](https://github.com/kubevault/cli/commit/a80515e1) Prepare for release v0.9.0-rc.0 (#157)
+- [932bb02e](https://github.com/kubevault/cli/commit/932bb02e) Add command for generating & rotating vault root token (#156)
+
+
+
+## [kubevault/installer](https://github.com/kubevault/installer)
+
+### [v2022.09.05-rc.0](https://github.com/kubevault/installer/releases/tag/v2022.09.05-rc.0)
+
+- [f07cba4](https://github.com/kubevault/installer/commit/f07cba4) Prepare for release v2022.09.05-rc.0 (#175)
+- [79473f3](https://github.com/kubevault/installer/commit/79473f3) Add recommendation engine flags & values (#174)
+- [9e14119](https://github.com/kubevault/installer/commit/9e14119) Update installer for vault ops-request (#172)
+- [1f3e429](https://github.com/kubevault/installer/commit/1f3e429) Add permission for license-proxyserver (#173)
+
+
+
+## [kubevault/operator](https://github.com/kubevault/operator)
+
+### [v0.9.0-rc.0](https://github.com/kubevault/operator/releases/tag/v0.9.0-rc.0)
+
+- [69442f24](https://github.com/kubevault/operator/commit/69442f24) Prepare for release v0.9.0-rc.0 (#70)
+- [b3e7e701](https://github.com/kubevault/operator/commit/b3e7e701) Add recommendation engine for vault server (#68)
+- [1264f212](https://github.com/kubevault/operator/commit/1264f212) Add support for RotateTLS and Restart Ops-Request (#66)
+- [a7968a97](https://github.com/kubevault/operator/commit/a7968a97) Stop using removed apis in Kubernetes 1.25 (#69)
+- [81a8f84f](https://github.com/kubevault/operator/commit/81a8f84f) Acquire license from license-proxyserver if available (#67)
+
+
+
+## [kubevault/unsealer](https://github.com/kubevault/unsealer)
+
+### [v0.9.0-rc.0](https://github.com/kubevault/unsealer/releases/tag/v0.9.0-rc.0)
+
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2022.09.05-rc.0
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/29
Signed-off-by: 1gtm <1gtm@appscode.com>