### PR TITLE
Prepare for release v2022.09.22

### DIFF
--- a/docs/CHANGELOG-v2022.09.22.md
+++ b/docs/CHANGELOG-v2022.09.22.md
@@ -1,0 +1,72 @@
+---
+title: Changelog | KubeVault
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubevault-v2022.09.22
+    name: Changelog-v2022.09.22
+    parent: welcome
+    weight: 20220922
+product_name: kubevault
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2022.09.22/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2022.09.22/
+---
+
+# KubeVault v2022.09.22 (2022-09-22)
+
+
+## [kubevault/apimachinery](https://github.com/kubevault/apimachinery)
+
+### [v0.10.0](https://github.com/kubevault/apimachinery/releases/tag/v0.10.0)
+
+- [d0491184](https://github.com/kubevault/apimachinery/commit/d0491184) Fix conversion (#63)
+- [42a9f95c](https://github.com/kubevault/apimachinery/commit/42a9f95c) Fix K8s version
+- [d8e6f760](https://github.com/kubevault/apimachinery/commit/d8e6f760) Use Go 1.19 (#65)
+- [7fce2029](https://github.com/kubevault/apimachinery/commit/7fce2029) Use k8s 1.25.1 libs (#64)
+
+
+
+## [kubevault/cli](https://github.com/kubevault/cli)
+
+### [v0.10.0](https://github.com/kubevault/cli/releases/tag/v0.10.0)
+
+- [5372dba7](https://github.com/kubevault/cli/commit/5372dba7) Prepare for release v0.10.0 (#161)
+- [015176a9](https://github.com/kubevault/cli/commit/015176a9) Use Go 1.19 (#160)
+- [67ec5d36](https://github.com/kubevault/cli/commit/67ec5d36) Use k8s 1.25.1 libs (#159)
+
+
+
+## [kubevault/installer](https://github.com/kubevault/installer)
+
+### [v2022.09.22](https://github.com/kubevault/installer/releases/tag/v2022.09.22)
+
+- [bbbc40a](https://github.com/kubevault/installer/commit/bbbc40a) Prepare for release v2022.09.22 (#180)
+- [ca42d02](https://github.com/kubevault/installer/commit/ca42d02) Update crds (#178)
+- [f1c6c62](https://github.com/kubevault/installer/commit/f1c6c62) Test against k8s 1.25.0 (#179)
+- [bb28027](https://github.com/kubevault/installer/commit/bb28027) Use Go 1.19 (#177)
+
+
+
+## [kubevault/operator](https://github.com/kubevault/operator)
+
+### [v0.10.0](https://github.com/kubevault/operator/releases/tag/v0.10.0)
+
+- [10e80edb](https://github.com/kubevault/operator/commit/10e80edb) Prepare for release v0.10.0 (#76)
+- [4411a557](https://github.com/kubevault/operator/commit/4411a557) Fix Sealed phase calculation (#73)
+- [38c5a35b](https://github.com/kubevault/operator/commit/38c5a35b) Use Go 1.19 (#75)
+- [bd9e7124](https://github.com/kubevault/operator/commit/bd9e7124) Use k8s 1.25.1 libs (#74)
+
+
+
+## [kubevault/unsealer](https://github.com/kubevault/unsealer)
+
+### [v0.10.0](https://github.com/kubevault/unsealer/releases/tag/v0.10.0)
+
+- [c1711c20](https://github.com/kubevault/unsealer/commit/c1711c20) Use Go 1.19 (#121)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2022.09.22
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/31
Signed-off-by: 1gtm <1gtm@appscode.com>