### PR TITLE
Prepare for release v2022.11.30

### DIFF
--- a/docs/CHANGELOG-v2022.11.30.md
+++ b/docs/CHANGELOG-v2022.11.30.md
@@ -1,0 +1,69 @@
+---
+title: Changelog | KubeVault
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubevault-v2022.11.30
+    name: Changelog-v2022.11.30
+    parent: welcome
+    weight: 20221130
+product_name: kubevault
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2022.11.30/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2022.11.30/
+---
+
+# KubeVault v2022.11.30 (2022-11-30)
+
+
+## [kubevault/apimachinery](https://github.com/kubevault/apimachinery)
+
+### [v0.11.0](https://github.com/kubevault/apimachinery/releases/tag/v0.11.0)
+
+- [6d5535a8](https://github.com/kubevault/apimachinery/commit/6d5535a8) Update VaultServerConfig with BackupSecret (#68)
+- [e2b451c5](https://github.com/kubevault/apimachinery/commit/e2b451c5) Update testing lib
+- [ffe70235](https://github.com/kubevault/apimachinery/commit/ffe70235) Use gomodules.xyz/testing
+- [c5e99527](https://github.com/kubevault/apimachinery/commit/c5e99527) Rename ACLTokenSecretName to ACLTokenSecretRef (#67)
+- [8b47cc1b](https://github.com/kubevault/apimachinery/commit/8b47cc1b) Test against Kubernetes 1.25.0 (#66)
+
+
+
+## [kubevault/cli](https://github.com/kubevault/cli)
+
+### [v0.11.0](https://github.com/kubevault/cli/releases/tag/v0.11.0)
+
+- [ec9eba04](https://github.com/kubevault/cli/commit/ec9eba04) Prepare for release v0.11.0 (#164)
+
+
+
+## [kubevault/installer](https://github.com/kubevault/installer)
+
+### [v2022.11.30](https://github.com/kubevault/installer/releases/tag/v2022.11.30)
+
+- [fb40772](https://github.com/kubevault/installer/commit/fb40772) Prepare for release v2022.11.30 (#184)
+- [2ca1152](https://github.com/kubevault/installer/commit/2ca1152) Add Vault Versions v1.11.5, v1.12.1 (#183)
+
+
+
+## [kubevault/operator](https://github.com/kubevault/operator)
+
+### [v0.11.0](https://github.com/kubevault/operator/releases/tag/v0.11.0)
+
+- [c2e9a825](https://github.com/kubevault/operator/commit/c2e9a825) Prepare for release v0.11.0 (#81)
+- [1ef7298b](https://github.com/kubevault/operator/commit/1ef7298b) Configure Vault Backup (#79)
+- [e7da2b32](https://github.com/kubevault/operator/commit/e7da2b32) Acquire license from proxyserver (#80)
+- [fbaa897b](https://github.com/kubevault/operator/commit/fbaa897b) Rename ACLTokenSecretName to ACLTokenSecretRef (#78)
+
+
+
+## [kubevault/unsealer](https://github.com/kubevault/unsealer)
+
+### [v0.11.0](https://github.com/kubevault/unsealer/releases/tag/v0.11.0)
+
+- [88f9ae0e](https://github.com/kubevault/unsealer/commit/88f9ae0e) Test against Kubernetes 1.25.0 (#122)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2022.11.30
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/33
Signed-off-by: 1gtm <1gtm@appscode.com>