### PR TITLE
Prepare for release v2022.12.09

### DIFF
--- a/docs/CHANGELOG-v2022.12.09.md
+++ b/docs/CHANGELOG-v2022.12.09.md
@@ -1,0 +1,65 @@
+---
+title: Changelog | KubeVault
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubevault-v2022.12.09
+    name: Changelog-v2022.12.09
+    parent: welcome
+    weight: 20221209
+product_name: kubevault
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2022.12.09/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2022.12.09/
+---
+
+# KubeVault v2022.12.09 (2022-12-09)
+
+
+## [kubevault/apimachinery](https://github.com/kubevault/apimachinery)
+
+### [v0.12.0](https://github.com/kubevault/apimachinery/releases/tag/v0.12.0)
+
+- [ee1cd930](https://github.com/kubevault/apimachinery/commit/ee1cd930) Add Backend & Unsealer info in AppBinding (#69)
+- [6f0b7f16](https://github.com/kubevault/apimachinery/commit/6f0b7f16) Run GH actions on ubuntu-20.04 (#70)
+
+
+
+## [kubevault/cli](https://github.com/kubevault/cli)
+
+### [v0.12.0](https://github.com/kubevault/cli/releases/tag/v0.12.0)
+
+- [56cc5750](https://github.com/kubevault/cli/commit/56cc5750) Prepare for release v0.12.0 (#166)
+- [0ca1aff0](https://github.com/kubevault/cli/commit/0ca1aff0) Run GH actions on ubuntu-20.04 (#165)
+
+
+
+## [kubevault/installer](https://github.com/kubevault/installer)
+
+### [v2022.12.09](https://github.com/kubevault/installer/releases/tag/v2022.12.09)
+
+- [df5997d](https://github.com/kubevault/installer/commit/df5997d) Prepare for release v2022.12.09 (#186)
+- [a62af67](https://github.com/kubevault/installer/commit/a62af67) Run GH actions on ubuntu-20.04 (#185)
+
+
+
+## [kubevault/operator](https://github.com/kubevault/operator)
+
+### [v0.12.0](https://github.com/kubevault/operator/releases/tag/v0.12.0)
+
+- [7a55dc9b](https://github.com/kubevault/operator/commit/7a55dc9b) Prepare for release v0.12.0 (#84)
+- [2019e0c2](https://github.com/kubevault/operator/commit/2019e0c2) Update AppBinding with Unsealer & Backend info (#82)
+- [7c2f651a](https://github.com/kubevault/operator/commit/7c2f651a) Run GH actions on ubuntu-20.04 (#83)
+
+
+
+## [kubevault/unsealer](https://github.com/kubevault/unsealer)
+
+### [v0.12.0](https://github.com/kubevault/unsealer/releases/tag/v0.12.0)
+
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2022.12.09
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/35
Signed-off-by: 1gtm <1gtm@appscode.com>