### PR TITLE
Prepare for release v2022.12.28

### DIFF
--- a/docs/CHANGELOG-v2022.12.28.md
+++ b/docs/CHANGELOG-v2022.12.28.md
@@ -1,0 +1,65 @@
+---
+title: Changelog | KubeVault
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubevault-v2022.12.28
+    name: Changelog-v2022.12.28
+    parent: welcome
+    weight: 20221228
+product_name: kubevault
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2022.12.28/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2022.12.28/
+---
+
+# KubeVault v2022.12.28 (2022-12-28)
+
+
+## [kubevault/apimachinery](https://github.com/kubevault/apimachinery)
+
+### [v0.13.0](https://github.com/kubevault/apimachinery/releases/tag/v0.13.0)
+
+- [3e0d8ee9](https://github.com/kubevault/apimachinery/commit/3e0d8ee9) Add Redis Secret Engine APIs (#72)
+
+
+
+## [kubevault/cli](https://github.com/kubevault/cli)
+
+### [v0.13.0](https://github.com/kubevault/cli/releases/tag/v0.13.0)
+
+- [85d3fa76](https://github.com/kubevault/cli/commit/85d3fa76) Prepare for release v0.13.0 (#169)
+
+
+
+## [kubevault/installer](https://github.com/kubevault/installer)
+
+### [v2022.12.28](https://github.com/kubevault/installer/releases/tag/v2022.12.28)
+
+- [6f187f3](https://github.com/kubevault/installer/commit/6f187f3) Prepare for release v2022.12.28 (#188)
+- [de77c42](https://github.com/kubevault/installer/commit/de77c42) Add Redis Secret Engine (#187)
+
+
+
+## [kubevault/operator](https://github.com/kubevault/operator)
+
+### [v0.13.0](https://github.com/kubevault/operator/releases/tag/v0.13.0)
+
+- [1a328fcc](https://github.com/kubevault/operator/commit/1a328fcc) Prepare for release v0.13.0 (#87)
+- [5c53d615](https://github.com/kubevault/operator/commit/5c53d615) Update Google Dependency (#88)
+- [9d173a3c](https://github.com/kubevault/operator/commit/9d173a3c) Add Redis Secret Engine (#85)
+- [f17e68d9](https://github.com/kubevault/operator/commit/f17e68d9) Update dependencies (#86)
+
+
+
+## [kubevault/unsealer](https://github.com/kubevault/unsealer)
+
+### [v0.13.0](https://github.com/kubevault/unsealer/releases/tag/v0.13.0)
+
+- [f8e44cf0](https://github.com/kubevault/unsealer/commit/f8e44cf0) Run GH actions on ubuntu-20.04 (#123)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2022.12.28
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/38
Signed-off-by: 1gtm <1gtm@appscode.com>