### PR TITLE
Prepare for release v2023.03.03

### DIFF
--- a/docs/CHANGELOG-v2023.03.03.md
+++ b/docs/CHANGELOG-v2023.03.03.md
@@ -1,0 +1,75 @@
+---
+title: Changelog | KubeVault
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubevault-v2023.03.03
+    name: Changelog-v2023.03.03
+    parent: welcome
+    weight: 20230303
+product_name: kubevault
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2023.03.03/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2023.03.03/
+---
+
+# KubeVault v2023.03.03 (2023-03-03)
+
+
+## [kubevault/apimachinery](https://github.com/kubevault/apimachinery)
+
+### [v0.14.0](https://github.com/kubevault/apimachinery/releases/tag/v0.14.0)
+
+- [d6fde647](https://github.com/kubevault/apimachinery/commit/d6fde647) Some cleanup
+- [ed87b314](https://github.com/kubevault/apimachinery/commit/ed87b314) Update wrokflows (Go 1.20, k8s 1.26) (#77)
+- [9bd6be24](https://github.com/kubevault/apimachinery/commit/9bd6be24) Mark exported field optional in Version CRD (#74)
+- [6e847734](https://github.com/kubevault/apimachinery/commit/6e847734) Update wrokflows (Go 1.20, k8s 1.26) (#75)
+- [c64f0bc7](https://github.com/kubevault/apimachinery/commit/c64f0bc7) Use api constants for tls.crt
+- [67d27681](https://github.com/kubevault/apimachinery/commit/67d27681) Add Prometheus Monitoring (#73)
+
+
+
+## [kubevault/cli](https://github.com/kubevault/cli)
+
+### [v0.14.0](https://github.com/kubevault/cli/releases/tag/v0.14.0)
+
+- [d8533125](https://github.com/kubevault/cli/commit/d8533125) Prepare for release v0.14.0 (#172)
+- [8b29d08d](https://github.com/kubevault/cli/commit/8b29d08d) Update workflows (Go 1.20, k8s 1.26) (#171)
+
+
+
+## [kubevault/installer](https://github.com/kubevault/installer)
+
+### [v2023.03.03](https://github.com/kubevault/installer/releases/tag/v2023.03.03)
+
+- [f346362](https://github.com/kubevault/installer/commit/f346362) Prepare for release v2023.03.03 (#196)
+- [8d001ff](https://github.com/kubevault/installer/commit/8d001ff) Update Makefile
+- [a14b739](https://github.com/kubevault/installer/commit/a14b739) Add opscenter and grafana-dashboard charts (#194)
+- [83a1380](https://github.com/kubevault/installer/commit/83a1380) Pass license to kubevault-webhook-server chart
+- [559a94e](https://github.com/kubevault/installer/commit/559a94e) Update workflows (Go 1.20, k8s 1.26) (#193)
+- [af49db4](https://github.com/kubevault/installer/commit/af49db4) Add MetricsConfiguration for VaultServer (#190)
+
+
+
+## [kubevault/operator](https://github.com/kubevault/operator)
+
+### [v0.14.0](https://github.com/kubevault/operator/releases/tag/v0.14.0)
+
+- [564680ca](https://github.com/kubevault/operator/commit/564680ca) Prepare for release v0.14.0 (#92)
+- [48131355](https://github.com/kubevault/operator/commit/48131355) Update workflows (Go 1.20, k8s 1.26) (#91)
+- [ead6eed7](https://github.com/kubevault/operator/commit/ead6eed7) Add Prometheus Monitoring (#89)
+- [add7a1ca](https://github.com/kubevault/operator/commit/add7a1ca) Set registryFQDN to use docker (#90)
+
+
+
+## [kubevault/unsealer](https://github.com/kubevault/unsealer)
+
+### [v0.14.0](https://github.com/kubevault/unsealer/releases/tag/v0.14.0)
+
+- [d609c8e3](https://github.com/kubevault/unsealer/commit/d609c8e3) Update wrokflows (Go 1.20, k8s 1.26) (#126)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2023.03.03
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/40
Signed-off-by: 1gtm <1gtm@appscode.com>