### PR TITLE
Prepare for release v2023.05.05

### DIFF
--- a/docs/CHANGELOG-v2023.05.05.md
+++ b/docs/CHANGELOG-v2023.05.05.md
@@ -1,0 +1,82 @@
+---
+title: Changelog | KubeVault
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubevault-v2023.05.05
+    name: Changelog-v2023.05.05
+    parent: welcome
+    weight: 20230505
+product_name: kubevault
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2023.05.05/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2023.05.05/
+---
+
+# KubeVault v2023.05.05 (2023-05-05)
+
+
+## [kubevault/apimachinery](https://github.com/kubevault/apimachinery)
+
+### [v0.15.0](https://github.com/kubevault/apimachinery/releases/tag/v0.15.0)
+
+- [9eef185c](https://github.com/kubevault/apimachinery/commit/9eef185c) Add enableServiceLinks to pod spec
+- [22ad2d1b](https://github.com/kubevault/apimachinery/commit/22ad2d1b) Test against K8s 1.27.1 (#82)
+- [d3e98559](https://github.com/kubevault/apimachinery/commit/d3e98559) Use uid 65534 and test against K8s 1.27.0 (#81)
+- [f6a0ef16](https://github.com/kubevault/apimachinery/commit/f6a0ef16) Use ghcr.io/appscode/gengo (#80)
+- [00cbce63](https://github.com/kubevault/apimachinery/commit/00cbce63) Use ghcr.io for appscode/golang-dev (#79)
+- [8f21c8dd](https://github.com/kubevault/apimachinery/commit/8f21c8dd) Update workflows (Go 1.20, k8s 1.26) (#78)
+
+
+
+## [kubevault/cli](https://github.com/kubevault/cli)
+
+### [v0.15.0](https://github.com/kubevault/cli/releases/tag/v0.15.0)
+
+- [139070bf](https://github.com/kubevault/cli/commit/139070bf) Prepare for release v0.15.0 (#175)
+- [86f87a0a](https://github.com/kubevault/cli/commit/86f87a0a) Use ghcr.io for appscode/golang-dev (#174)
+- [ce2d1f90](https://github.com/kubevault/cli/commit/ce2d1f90) Update workflows (Go 1.20, k8s 1.26) (#173)
+
+
+
+## [kubevault/installer](https://github.com/kubevault/installer)
+
+### [v2023.05.05](https://github.com/kubevault/installer/releases/tag/v2023.05.05)
+
+- [eb90293](https://github.com/kubevault/installer/commit/eb90293) Prepare for release v2023.05.05 (#202)
+- [a43f89a](https://github.com/kubevault/installer/commit/a43f89a) Test against K8s 1.27.1 (#201)
+- [10c283c](https://github.com/kubevault/installer/commit/10c283c) Use uid 65534 and test against K8s 1.27.0 (#200)
+- [a07923e](https://github.com/kubevault/installer/commit/a07923e) Use ghcr.io/appscode/gengo (#199)
+- [c1d0d8b](https://github.com/kubevault/installer/commit/c1d0d8b) Stop publishing to docker hub
+- [f66a6cd](https://github.com/kubevault/installer/commit/f66a6cd) Use ghcr.io for appscode/golang-dev (#198)
+- [e246fef](https://github.com/kubevault/installer/commit/e246fef) Update workflows (Go 1.20, k8s 1.26) (#197)
+
+
+
+## [kubevault/operator](https://github.com/kubevault/operator)
+
+### [v0.15.0](https://github.com/kubevault/operator/releases/tag/v0.15.0)
+
+- [65c11c92](https://github.com/kubevault/operator/commit/65c11c92) Prepare for release v0.15.0 (#99)
+- [2836dc90](https://github.com/kubevault/operator/commit/2836dc90) Configure enableServiceLinks to pod spec (#98)
+- [6773611a](https://github.com/kubevault/operator/commit/6773611a) Add Random Suffix with Secret Name (#97)
+- [7536eece](https://github.com/kubevault/operator/commit/7536eece) Create SA Token Secret if it does not exist (#96)
+- [53843506](https://github.com/kubevault/operator/commit/53843506) Use uid 65534 and test against K8s 1.27.0 (#95)
+- [fcc21ef1](https://github.com/kubevault/operator/commit/fcc21ef1) Use ghcr.io for appscode/golang-dev (#94)
+- [20b4f38e](https://github.com/kubevault/operator/commit/20b4f38e) Update workflows (Go 1.20, k8s 1.26) (#93)
+
+
+
+## [kubevault/unsealer](https://github.com/kubevault/unsealer)
+
+### [v0.15.0](https://github.com/kubevault/unsealer/releases/tag/v0.15.0)
+
+- [bba14525](https://github.com/kubevault/unsealer/commit/bba14525) Use uid 65534 and test against K8s 1.27.0 (#129)
+- [4d994ade](https://github.com/kubevault/unsealer/commit/4d994ade) Use ghcr.io for appscode/golang-dev (#128)
+- [7a13d331](https://github.com/kubevault/unsealer/commit/7a13d331) Update workflows (Go 1.20, k8s 1.26) (#127)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2023.05.05
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/42
Signed-off-by: 1gtm <1gtm@appscode.com>