### PR TITLE
Prepare for release v2024.1.26-rc.0

### DIFF
--- a/docs/CHANGELOG-v2024.1.26-rc.0.md
+++ b/docs/CHANGELOG-v2024.1.26-rc.0.md
@@ -1,0 +1,69 @@
+---
+title: Changelog | KubeVault
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubevault-v2024.1.26-rc.0
+    name: Changelog-v2024.1.26-rc.0
+    parent: welcome
+    weight: 20240126
+product_name: kubevault
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2024.1.26-rc.0/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2024.1.26-rc.0/
+---
+
+# KubeVault v2024.1.26-rc.0 (2024-01-27)
+
+
+## [kubevault/apimachinery](https://github.com/kubevault/apimachinery)
+
+### [v0.17.0-rc.0](https://github.com/kubevault/apimachinery/releases/tag/v0.17.0-rc.0)
+
+- [ca33ed7d](https://github.com/kubevault/apimachinery/commit/ca33ed7d) Add ConfigureOpenAPI helper (#92)
+- [9853d93f](https://github.com/kubevault/apimachinery/commit/9853d93f) Update crd fuzzer (#91)
+- [6c42ed81](https://github.com/kubevault/apimachinery/commit/6c42ed81) Use k8s 1.29 client libs (#90)
+
+
+
+## [kubevault/cli](https://github.com/kubevault/cli)
+
+### [v0.17.0-rc.0](https://github.com/kubevault/cli/releases/tag/v0.17.0-rc.0)
+
+- [d3c67d43](https://github.com/kubevault/cli/commit/d3c67d43) Prepare for release v0.17.0-rc.0 (#185)
+- [9c748ba6](https://github.com/kubevault/cli/commit/9c748ba6) Use k8s 1.29 client libs (#184)
+
+
+
+## [kubevault/installer](https://github.com/kubevault/installer)
+
+### [v2024.1.26-rc.0](https://github.com/kubevault/installer/releases/tag/v2024.1.26-rc.0)
+
+- [299385d](https://github.com/kubevault/installer/commit/299385d) Prepare for release v2024.1.26-rc.0 (#225)
+- [9e1c356](https://github.com/kubevault/installer/commit/9e1c356) Use k8s 1.29 client libs (#224)
+- [04c5a03](https://github.com/kubevault/installer/commit/04c5a03) Check for image existence (#221)
+
+
+
+## [kubevault/operator](https://github.com/kubevault/operator)
+
+### [v0.17.0-rc.0](https://github.com/kubevault/operator/releases/tag/v0.17.0-rc.0)
+
+- [9e704219](https://github.com/kubevault/operator/commit/9e704219) Prepare for release v0.17.0-rc.0 (#115)
+- [7005dcc7](https://github.com/kubevault/operator/commit/7005dcc7) Use k8s 1.29 client libs (#114)
+- [992f326d](https://github.com/kubevault/operator/commit/992f326d) Send hourly audit events (#112)
+
+
+
+## [kubevault/unsealer](https://github.com/kubevault/unsealer)
+
+### [v0.17.0-rc.0](https://github.com/kubevault/unsealer/releases/tag/v0.17.0-rc.0)
+
+- [f46b417e](https://github.com/kubevault/unsealer/commit/f46b417e) Use k8s 1.29 client libs (#133)
+- [46940e31](https://github.com/kubevault/unsealer/commit/46940e31) Use k8s 1.29 client libs (#132)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2024.1.26-rc.0
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/46
Signed-off-by: 1gtm <1gtm@appscode.com>