### PR TITLE
Prepare for release v2024.1.28-rc.1

### DIFF
--- a/docs/CHANGELOG-v2024.1.28-rc.1.md
+++ b/docs/CHANGELOG-v2024.1.28-rc.1.md
@@ -1,0 +1,64 @@
+---
+title: Changelog | KubeVault
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubevault-v2024.1.28-rc.1
+    name: Changelog-v2024.1.28-rc.1
+    parent: welcome
+    weight: 20240128
+product_name: kubevault
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2024.1.28-rc.1/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2024.1.28-rc.1/
+---
+
+# KubeVault v2024.1.28-rc.1 (2024-01-28)
+
+
+## [kubevault/apimachinery](https://github.com/kubevault/apimachinery)
+
+### [v0.17.0-rc.1](https://github.com/kubevault/apimachinery/releases/tag/v0.17.0-rc.1)
+
+- [c1e6d898](https://github.com/kubevault/apimachinery/commit/c1e6d898) Update deps
+
+
+
+## [kubevault/cli](https://github.com/kubevault/cli)
+
+### [v0.17.0-rc.1](https://github.com/kubevault/cli/releases/tag/v0.17.0-rc.1)
+
+- [18eaa3b5](https://github.com/kubevault/cli/commit/18eaa3b5) Prepare for release v0.17.0-rc.1 (#188)
+- [74190f7c](https://github.com/kubevault/cli/commit/74190f7c) Use deps (#187)
+
+
+
+## [kubevault/installer](https://github.com/kubevault/installer)
+
+### [v2024.1.28-rc.1](https://github.com/kubevault/installer/releases/tag/v2024.1.28-rc.1)
+
+- [2f29a5e](https://github.com/kubevault/installer/commit/2f29a5e) Prepare for release v2024.1.28-rc.1 (#227)
+- [bf6ad16](https://github.com/kubevault/installer/commit/bf6ad16) Use deps (#226)
+
+
+
+## [kubevault/operator](https://github.com/kubevault/operator)
+
+### [v0.17.0-rc.1](https://github.com/kubevault/operator/releases/tag/v0.17.0-rc.1)
+
+- [94a6564a](https://github.com/kubevault/operator/commit/94a6564a) Prepare for release v0.17.0-rc.1 (#117)
+- [fb390cf6](https://github.com/kubevault/operator/commit/fb390cf6) Use deps (#116)
+
+
+
+## [kubevault/unsealer](https://github.com/kubevault/unsealer)
+
+### [v0.17.0-rc.1](https://github.com/kubevault/unsealer/releases/tag/v0.17.0-rc.1)
+
+- [fdbbdc20](https://github.com/kubevault/unsealer/commit/fdbbdc20) Use deps (#134)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2024.1.28-rc.1
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/47
Signed-off-by: 1gtm <1gtm@appscode.com>