### PR TITLE
Prepare for release v2024.1.31

### DIFF
--- a/docs/CHANGELOG-v2024.1.31.md
+++ b/docs/CHANGELOG-v2024.1.31.md
@@ -1,0 +1,86 @@
+---
+title: Changelog | KubeVault
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubevault-v2024.1.31
+    name: Changelog-v2024.1.31
+    parent: welcome
+    weight: 20240131
+product_name: kubevault
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2024.1.31/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2024.1.31/
+---
+
+# KubeVault v2024.1.31 (2024-01-31)
+
+
+## [kubevault/apimachinery](https://github.com/kubevault/apimachinery)
+
+### [v0.17.0](https://github.com/kubevault/apimachinery/releases/tag/v0.17.0)
+
+- [c1e6d898](https://github.com/kubevault/apimachinery/commit/c1e6d898) Update deps
+- [ca33ed7d](https://github.com/kubevault/apimachinery/commit/ca33ed7d) Add ConfigureOpenAPI helper (#92)
+- [9853d93f](https://github.com/kubevault/apimachinery/commit/9853d93f) Update crd fuzzer (#91)
+- [6c42ed81](https://github.com/kubevault/apimachinery/commit/6c42ed81) Use k8s 1.29 client libs (#90)
+
+
+
+## [kubevault/cli](https://github.com/kubevault/cli)
+
+### [v0.17.0](https://github.com/kubevault/cli/releases/tag/v0.17.0)
+
+- [16fc1470](https://github.com/kubevault/cli/commit/16fc1470) Prepare for release v0.17.0 (#189)
+- [18eaa3b5](https://github.com/kubevault/cli/commit/18eaa3b5) Prepare for release v0.17.0-rc.1 (#188)
+- [74190f7c](https://github.com/kubevault/cli/commit/74190f7c) Use deps (#187)
+- [d3c67d43](https://github.com/kubevault/cli/commit/d3c67d43) Prepare for release v0.17.0-rc.0 (#185)
+- [9c748ba6](https://github.com/kubevault/cli/commit/9c748ba6) Use k8s 1.29 client libs (#184)
+
+
+
+## [kubevault/installer](https://github.com/kubevault/installer)
+
+### [v2024.1.31](https://github.com/kubevault/installer/releases/tag/v2024.1.31)
+
+- [fcd744f](https://github.com/kubevault/installer/commit/fcd744f) Prepare for release v2024.1.31 (#228)
+- [2f29a5e](https://github.com/kubevault/installer/commit/2f29a5e) Prepare for release v2024.1.28-rc.1 (#227)
+- [bf6ad16](https://github.com/kubevault/installer/commit/bf6ad16) Use deps (#226)
+- [299385d](https://github.com/kubevault/installer/commit/299385d) Prepare for release v2024.1.26-rc.0 (#225)
+- [9e1c356](https://github.com/kubevault/installer/commit/9e1c356) Use k8s 1.29 client libs (#224)
+- [04c5a03](https://github.com/kubevault/installer/commit/04c5a03) Check for image existence (#221)
+- [1addbed](https://github.com/kubevault/installer/commit/1addbed) Fix registry proxy templates
+- [036ffa3](https://github.com/kubevault/installer/commit/036ffa3) Remove k8s 1.19 from CI
+- [fbbedff](https://github.com/kubevault/installer/commit/fbbedff) Prepare release: v2023.10.26-rc.0 (#219)
+- [4652480](https://github.com/kubevault/installer/commit/4652480) Update catalog registry templates (#216)
+- [8770e07](https://github.com/kubevault/installer/commit/8770e07) Update deps
+
+
+
+## [kubevault/operator](https://github.com/kubevault/operator)
+
+### [v0.17.0](https://github.com/kubevault/operator/releases/tag/v0.17.0)
+
+- [84268ef1](https://github.com/kubevault/operator/commit/84268ef1) Prepare for release v0.17.0 (#119)
+- [3cfeac7b](https://github.com/kubevault/operator/commit/3cfeac7b) Fix Cloud Secret Engines (#118)
+- [94a6564a](https://github.com/kubevault/operator/commit/94a6564a) Prepare for release v0.17.0-rc.1 (#117)
+- [fb390cf6](https://github.com/kubevault/operator/commit/fb390cf6) Use deps (#116)
+- [9e704219](https://github.com/kubevault/operator/commit/9e704219) Prepare for release v0.17.0-rc.0 (#115)
+- [7005dcc7](https://github.com/kubevault/operator/commit/7005dcc7) Use k8s 1.29 client libs (#114)
+- [992f326d](https://github.com/kubevault/operator/commit/992f326d) Send hourly audit events (#112)
+
+
+
+## [kubevault/unsealer](https://github.com/kubevault/unsealer)
+
+### [v0.17.0](https://github.com/kubevault/unsealer/releases/tag/v0.17.0)
+
+- [fdbbdc20](https://github.com/kubevault/unsealer/commit/fdbbdc20) Use deps (#134)
+- [f46b417e](https://github.com/kubevault/unsealer/commit/f46b417e) Use k8s 1.29 client libs (#133)
+- [46940e31](https://github.com/kubevault/unsealer/commit/46940e31) Use k8s 1.29 client libs (#132)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2024.1.31
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/48
Signed-off-by: 1gtm <1gtm@appscode.com>