### PR TITLE
Prepare for release v2024.3.12

### DIFF
--- a/docs/CHANGELOG-v2024.3.12.md
+++ b/docs/CHANGELOG-v2024.3.12.md
@@ -1,0 +1,64 @@
+---
+title: Changelog | KubeVault
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubevault-v2024.3.12
+    name: Changelog-v2024.3.12
+    parent: welcome
+    weight: 20240312
+product_name: kubevault
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2024.3.12/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2024.3.12/
+---
+
+# KubeVault v2024.3.12 (2024-03-12)
+
+
+## [kubevault/apimachinery](https://github.com/kubevault/apimachinery)
+
+### [v0.18.0](https://github.com/kubevault/apimachinery/releases/tag/v0.18.0)
+
+- [f7c76e31](https://github.com/kubevault/apimachinery/commit/f7c76e31) Update deps
+- [be8c2cad](https://github.com/kubevault/apimachinery/commit/be8c2cad) Update deps
+- [82677dd7](https://github.com/kubevault/apimachinery/commit/82677dd7) Add PKI API (#93)
+
+
+
+## [kubevault/cli](https://github.com/kubevault/cli)
+
+### [v0.18.0](https://github.com/kubevault/cli/releases/tag/v0.18.0)
+
+- [0a26bfb9](https://github.com/kubevault/cli/commit/0a26bfb9) Prepare for release v0.18.0 (#190)
+
+
+
+## [kubevault/installer](https://github.com/kubevault/installer)
+
+### [v2024.3.12](https://github.com/kubevault/installer/releases/tag/v2024.3.12)
+
+- [7963d5d](https://github.com/kubevault/installer/commit/7963d5d) Prepare for release v2024.3.12 (#229)
+- [d589023](https://github.com/kubevault/installer/commit/d589023) Fix formatting
+
+
+
+## [kubevault/operator](https://github.com/kubevault/operator)
+
+### [v0.18.0](https://github.com/kubevault/operator/releases/tag/v0.18.0)
+
+- [558194fb](https://github.com/kubevault/operator/commit/558194fb) Prepare for release v0.18.0 (#121)
+- [67901b68](https://github.com/kubevault/operator/commit/67901b68) Add PKI Engine (#120)
+
+
+
+## [kubevault/unsealer](https://github.com/kubevault/unsealer)
+
+### [v0.18.0](https://github.com/kubevault/unsealer/releases/tag/v0.18.0)
+
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2024.3.12
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/49
Signed-off-by: 1gtm <1gtm@appscode.com>