### PR TITLE
Prepare for release v2024.9.30

### DIFF
--- a/docs/CHANGELOG-v2024.9.30.md
+++ b/docs/CHANGELOG-v2024.9.30.md
@@ -1,0 +1,79 @@
+---
+title: Changelog | KubeVault
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubevault-v2024.9.30
+    name: Changelog-v2024.9.30
+    parent: welcome
+    weight: 20240930
+product_name: kubevault
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2024.9.30/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2024.9.30/
+---
+
+# KubeVault v2024.9.30 (2024-09-27)
+
+
+## [kubevault/apimachinery](https://github.com/kubevault/apimachinery)
+
+### [v0.19.0](https://github.com/kubevault/apimachinery/releases/tag/v0.19.0)
+
+- [223cd4f7](https://github.com/kubevault/apimachinery/commit/223cd4f7) Update deps
+- [ae601415](https://github.com/kubevault/apimachinery/commit/ae601415) Use KIND v0.24.0 (#98)
+- [f4ffee13](https://github.com/kubevault/apimachinery/commit/f4ffee13) Use Go 1.23 (#97)
+- [e0f7e2f7](https://github.com/kubevault/apimachinery/commit/e0f7e2f7) Test against k8s 1.31 (#96)
+
+
+
+## [kubevault/cli](https://github.com/kubevault/cli)
+
+### [v0.19.0](https://github.com/kubevault/cli/releases/tag/v0.19.0)
+
+- [e9bae879](https://github.com/kubevault/cli/commit/e9bae879) Prepare for release v0.19.0 (#195)
+- [2ae41b88](https://github.com/kubevault/cli/commit/2ae41b88) Use Go 1.23 (#194)
+
+
+
+## [kubevault/installer](https://github.com/kubevault/installer)
+
+### [v2024.9.30](https://github.com/kubevault/installer/releases/tag/v2024.9.30)
+
+- [e12ee67](https://github.com/kubevault/installer/commit/e12ee67) Prepare for release v2024.9.30 (#238)
+- [f2759e3](https://github.com/kubevault/installer/commit/f2759e3) Use seccompProfile RuntimeDefault
+- [2b61714](https://github.com/kubevault/installer/commit/2b61714) Update charts
+- [581e7fd](https://github.com/kubevault/installer/commit/581e7fd) Add imagelist
+- [29358ad](https://github.com/kubevault/installer/commit/29358ad) Revise metrics config user roles
+- [d9a1943](https://github.com/kubevault/installer/commit/d9a1943) Remove appcatalog user roles
+- [58f6616](https://github.com/kubevault/installer/commit/58f6616) Revise user roles (#237)
+- [f44f881](https://github.com/kubevault/installer/commit/f44f881) Use KIND v0.24.0 (#236)
+- [1a8a998](https://github.com/kubevault/installer/commit/1a8a998) Use Go 1.23 (#235)
+- [02f56cc](https://github.com/kubevault/installer/commit/02f56cc) Test against k8s 1.31 (#234)
+- [413f44e](https://github.com/kubevault/installer/commit/413f44e) Fix ca cert key in service monitor
+- [ecdc628](https://github.com/kubevault/installer/commit/ecdc628) Remove license checks from webhook server (#232)
+
+
+
+## [kubevault/operator](https://github.com/kubevault/operator)
+
+### [v0.19.0](https://github.com/kubevault/operator/releases/tag/v0.19.0)
+
+- [9094e13f](https://github.com/kubevault/operator/commit/9094e13ff) Update deps
+- [a9ec7f93](https://github.com/kubevault/operator/commit/a9ec7f93e) Use Go 1.23 (#124)
+- [5f261077](https://github.com/kubevault/operator/commit/5f2610774) Remove license checks from the webhook server (#123)
+
+
+
+## [kubevault/unsealer](https://github.com/kubevault/unsealer)
+
+### [v0.19.0](https://github.com/kubevault/unsealer/releases/tag/v0.19.0)
+
+- [4ee4d0cd](https://github.com/kubevault/unsealer/commit/4ee4d0cd) Use Go 1.23 (#136)
+- [2e0d13e5](https://github.com/kubevault/unsealer/commit/2e0d13e5) Use Go 1.23 (#135)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2024.9.30
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/52
Signed-off-by: 1gtm <1gtm@appscode.com>