### PR TITLE
Prepare for release v2025.2.6-rc.0

### DIFF
--- a/docs/CHANGELOG-v2025.2.6-rc.0.md
+++ b/docs/CHANGELOG-v2025.2.6-rc.0.md
@@ -1,0 +1,106 @@
+---
+title: Changelog | KubeVault
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubevault-v2025.2.6-rc.0
+    name: Changelog-v2025.2.6-rc.0
+    parent: welcome
+    weight: 20250206
+product_name: kubevault
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2025.2.6-rc.0/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2025.2.6-rc.0/
+---
+
+# KubeVault v2025.2.6-rc.0 (2025-02-06)
+
+
+## [kubevault/apimachinery](https://github.com/kubevault/apimachinery)
+
+### [v0.20.0-rc.0](https://github.com/kubevault/apimachinery/releases/tag/v0.20.0-rc.0)
+
+- [01a5f6e4](https://github.com/kubevault/apimachinery/commit/01a5f6e4) Fix Makefile
+- [0b35b1ab](https://github.com/kubevault/apimachinery/commit/0b35b1ab) make gen fmt
+- [8f4ddb6f](https://github.com/kubevault/apimachinery/commit/8f4ddb6f) Update deps
+- [38cba2c5](https://github.com/kubevault/apimachinery/commit/38cba2c5) Remove deprecated api calls
+- [cd6099c2](https://github.com/kubevault/apimachinery/commit/cd6099c2) Add initContainer config option in VaultServerVersionSpec (#102)
+- [41aa54b8](https://github.com/kubevault/apimachinery/commit/41aa54b8) Update github action modules (#101)
+- [c8c5b186](https://github.com/kubevault/apimachinery/commit/c8c5b186) Use kind v0.25.0 (#100)
+- [b03363cd](https://github.com/kubevault/apimachinery/commit/b03363cd) Use debian:12 base image (#99)
+
+
+
+## [kubevault/cli](https://github.com/kubevault/cli)
+
+### [v0.20.0-rc.0](https://github.com/kubevault/cli/releases/tag/v0.20.0-rc.0)
+
+- [6fb84094](https://github.com/kubevault/cli/commit/6fb84094) Prepare for release v0.20.0-rc.0 (#197)
+- [59f2343b](https://github.com/kubevault/cli/commit/59f2343b) Update github action modules (#196)
+
+
+
+## [kubevault/installer](https://github.com/kubevault/installer)
+
+### [v2025.2.6-rc.0](https://github.com/kubevault/installer/releases/tag/v2025.2.6-rc.0)
+
+- [b4dd8b56](https://github.com/kubevault/installer/commit/b4dd8b56) Prepare for release v2025.2.6-rc.0 (#271)
+- [6ea74978](https://github.com/kubevault/installer/commit/6ea74978) Updates for adding `initContainer` in `VaultServerVersion` (#268)
+- [fe0a13ff](https://github.com/kubevault/installer/commit/fe0a13ff) Update deps
+- [329f0555](https://github.com/kubevault/installer/commit/329f0555) Move user roles to ace-user-roles chart (#269)
+- [f88df2d9](https://github.com/kubevault/installer/commit/f88df2d9) Update cve report (#267)
+- [ca21ddc8](https://github.com/kubevault/installer/commit/ca21ddc8) Update cve report (#266)
+- [0d75cf2b](https://github.com/kubevault/installer/commit/0d75cf2b) Update github action modules (#265)
+- [be2d6b21](https://github.com/kubevault/installer/commit/be2d6b21) Update github action modules (#263)
+- [6c9fce2b](https://github.com/kubevault/installer/commit/6c9fce2b) Update cve report (#262)
+- [b9d25d3c](https://github.com/kubevault/installer/commit/b9d25d3c) Update cve report (#261)
+- [698f50e7](https://github.com/kubevault/installer/commit/698f50e7) Update cve report (#260)
+- [bcf43d56](https://github.com/kubevault/installer/commit/bcf43d56) Update cve report (#259)
+- [aaadf533](https://github.com/kubevault/installer/commit/aaadf533) Check image arch (#258)
+- [9d6d3754](https://github.com/kubevault/installer/commit/9d6d3754) Update cve report (#257)
+- [9dbe35f9](https://github.com/kubevault/installer/commit/9dbe35f9) Update cve report (#256)
+- [cd329618](https://github.com/kubevault/installer/commit/cd329618) Update cve report (#255)
+- [d79a7249](https://github.com/kubevault/installer/commit/d79a7249) Use kind v0.25.0 (#254)
+- [3a304090](https://github.com/kubevault/installer/commit/3a304090) Update cve report (#253)
+- [622a78fe](https://github.com/kubevault/installer/commit/622a78fe) Update cve report (#252)
+- [3c5f4197](https://github.com/kubevault/installer/commit/3c5f4197) Update cve report (#251)
+- [220f1634](https://github.com/kubevault/installer/commit/220f1634) Update cve report (#250)
+- [4f10b560](https://github.com/kubevault/installer/commit/4f10b560) Update cve report (#249)
+- [a284ab49](https://github.com/kubevault/installer/commit/a284ab49) Update cve report (#248)
+- [7606fb0d](https://github.com/kubevault/installer/commit/7606fb0d) Update cve report (#247)
+- [2d1c6d81](https://github.com/kubevault/installer/commit/2d1c6d81) Update cve report (#246)
+- [c76eacb0](https://github.com/kubevault/installer/commit/c76eacb0) Update cve report (#245)
+- [2ba380d5](https://github.com/kubevault/installer/commit/2ba380d5) Update cve report (#244)
+- [c2cb5f45](https://github.com/kubevault/installer/commit/c2cb5f45) Update cve report (#243)
+- [ab6bb819](https://github.com/kubevault/installer/commit/ab6bb819) Update cve report (#242)
+- [3641fdc6](https://github.com/kubevault/installer/commit/3641fdc6) Update cve report (#241)
+- [f0c1ce0e](https://github.com/kubevault/installer/commit/f0c1ce0e) Update deps
+- [c71863a2](https://github.com/kubevault/installer/commit/c71863a2) Update cve report 2024-10-24 (#240)
+- [28418aa8](https://github.com/kubevault/installer/commit/28418aa8) Generate cve report
+- [7461a4b7](https://github.com/kubevault/installer/commit/7461a4b7) Use debian:12 base image (#239)
+
+
+
+## [kubevault/operator](https://github.com/kubevault/operator)
+
+### [v0.20.0-rc.0](https://github.com/kubevault/operator/releases/tag/v0.20.0-rc.0)
+
+- [eb1a68e0](https://github.com/kubevault/operator/commit/eb1a68e0d) Prepare for release v0.20.0-rc.0 (#128)
+- [59038294](https://github.com/kubevault/operator/commit/590382941) Updates for adding `initContainer` in `VaultServerVersion` (#127)
+- [4aba3e3d](https://github.com/kubevault/operator/commit/4aba3e3d0) Update github action modules (#126)
+- [3f72441a](https://github.com/kubevault/operator/commit/3f72441a0) Use debian:12 base image (#125)
+
+
+
+## [kubevault/unsealer](https://github.com/kubevault/unsealer)
+
+### [v0.20.0-rc.0](https://github.com/kubevault/unsealer/releases/tag/v0.20.0-rc.0)
+
+- [45ffd31c](https://github.com/kubevault/unsealer/commit/45ffd31c) Update github action modules (#138)
+- [47945d71](https://github.com/kubevault/unsealer/commit/47945d71) Use debian:12 base image (#137)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2025.2.6-rc.0
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/55
Signed-off-by: 1gtm <1gtm@appscode.com>