### PR TITLE
Prepare for release v2025.5.26

### DIFF
--- a/docs/CHANGELOG-v2025.5.26.md
+++ b/docs/CHANGELOG-v2025.5.26.md
@@ -1,0 +1,92 @@
+---
+title: Changelog | KubeVault
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubevault-v2025.5.26
+    name: Changelog-v2025.5.26
+    parent: welcome
+    weight: 20250526
+product_name: kubevault
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2025.5.26/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2025.5.26/
+---
+
+# KubeVault v2025.5.26 (2025-05-26)
+
+
+## [kubevault/apimachinery](https://github.com/kubevault/apimachinery)
+
+### [v0.21.0](https://github.com/kubevault/apimachinery/releases/tag/v0.21.0)
+
+- [6afe114b](https://github.com/kubevault/apimachinery/commit/6afe114b) Use k8s 1.32
+- [2c22f1c1](https://github.com/kubevault/apimachinery/commit/2c22f1c1) Test against k8s 1.32 (#109)
+- [35becfa4](https://github.com/kubevault/apimachinery/commit/35becfa4) Test against k8s 1.32 (#108)
+- [7e13a0f6](https://github.com/kubevault/apimachinery/commit/7e13a0f6) Test against k8s 1.32 (#107)
+- [986b66bc](https://github.com/kubevault/apimachinery/commit/986b66bc) Test against k8s 1.32 (#106)
+- [c43e3784](https://github.com/kubevault/apimachinery/commit/c43e3784) Test against k8s 1.32 (#105)
+- [3aec0d8c](https://github.com/kubevault/apimachinery/commit/3aec0d8c) Use Go 1.24 (#104)
+
+
+
+## [kubevault/cli](https://github.com/kubevault/cli)
+
+### [v0.21.0](https://github.com/kubevault/cli/releases/tag/v0.21.0)
+
+- [d3c3cf7c](https://github.com/kubevault/cli/commit/d3c3cf7c) Prepare for release v0.21.0 (#207)
+- [aa8b8f31](https://github.com/kubevault/cli/commit/aa8b8f31) Use k8s 1.32 client libs (#206)
+- [11b40eef](https://github.com/kubevault/cli/commit/11b40eef) Use Go 1.24 (#200)
+
+
+
+## [kubevault/installer](https://github.com/kubevault/installer)
+
+### [v2025.5.26](https://github.com/kubevault/installer/releases/tag/v2025.5.26)
+
+- [a9d9a42e](https://github.com/kubevault/installer/commit/a9d9a42e) Prepare for release v2025.5.26 (#309)
+- [23a0bde6](https://github.com/kubevault/installer/commit/23a0bde6) Use k8s 1.32 (#308)
+- [4970f5d2](https://github.com/kubevault/installer/commit/4970f5d2) Add option to pass priorityclass name to operator pod (#307)
+- [e1e3a454](https://github.com/kubevault/installer/commit/e1e3a454) Update cve report (#306)
+- [8e529009](https://github.com/kubevault/installer/commit/8e529009) Update cve report (#305)
+- [56c75c24](https://github.com/kubevault/installer/commit/56c75c24) Update cve report (#304)
+- [2cb5d594](https://github.com/kubevault/installer/commit/2cb5d594) Update cve report (#303)
+- [dfe16fd7](https://github.com/kubevault/installer/commit/dfe16fd7) Update cve report (#302)
+- [c86852c8](https://github.com/kubevault/installer/commit/c86852c8) Update cve report (#300)
+- [8650f0a9](https://github.com/kubevault/installer/commit/8650f0a9) Update cve report (#298)
+- [fc69aedf](https://github.com/kubevault/installer/commit/fc69aedf) Update cve report (#297)
+- [fdbd2dc1](https://github.com/kubevault/installer/commit/fdbd2dc1) Update cve report (#296)
+- [9b45640b](https://github.com/kubevault/installer/commit/9b45640b) Update cve report (#295)
+- [fb9ea5a4](https://github.com/kubevault/installer/commit/fb9ea5a4) Update cve report (#294)
+- [2d93c3c0](https://github.com/kubevault/installer/commit/2d93c3c0) Update cve report (#293)
+- [5c39aab3](https://github.com/kubevault/installer/commit/5c39aab3) Update ace-user-roles
+- [86245f71](https://github.com/kubevault/installer/commit/86245f71) Test against k8s 1.32 (#291)
+- [e3f0678d](https://github.com/kubevault/installer/commit/e3f0678d) Update cve report (#290)
+- [0193897e](https://github.com/kubevault/installer/commit/0193897e) Test against k8s 1.32 (#289)
+- [ab39ac08](https://github.com/kubevault/installer/commit/ab39ac08) Update cve report (#288)
+- [dbc9f752](https://github.com/kubevault/installer/commit/dbc9f752) Update cve report (#287)
+
+
+
+## [kubevault/operator](https://github.com/kubevault/operator)
+
+### [v0.21.0](https://github.com/kubevault/operator/releases/tag/v0.21.0)
+
+- [195b7bf3](https://github.com/kubevault/operator/commit/195b7bf30) Prepare for release v0.21.0 (#136)
+- [93d5cfa2](https://github.com/kubevault/operator/commit/93d5cfa20) Use k8s 1.32 client libs (#135)
+- [094ca87c](https://github.com/kubevault/operator/commit/094ca87c7) make fmt (#134)
+
+
+
+## [kubevault/unsealer](https://github.com/kubevault/unsealer)
+
+### [v0.21.0](https://github.com/kubevault/unsealer/releases/tag/v0.21.0)
+
+- [6a870669](https://github.com/kubevault/unsealer/commit/6a870669) Use k8s 1.32 client libs (#141)
+- [7037b619](https://github.com/kubevault/unsealer/commit/7037b619) Use Go 1.24 (#140)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2025.5.26
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/58
Signed-off-by: 1gtm <1gtm@appscode.com>