### PR TITLE
Prepare for release v2025.5.30

### DIFF
--- a/docs/CHANGELOG-v2025.5.30.md
+++ b/docs/CHANGELOG-v2025.5.30.md
@@ -1,0 +1,61 @@
+---
+title: Changelog | KubeVault
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubevault-v2025.5.30
+    name: Changelog-v2025.5.30
+    parent: welcome
+    weight: 20250530
+product_name: kubevault
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2025.5.30/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2025.5.30/
+---
+
+# KubeVault v2025.5.30 (2025-05-29)
+
+
+## [kubevault/apimachinery](https://github.com/kubevault/apimachinery)
+
+### [v0.22.0](https://github.com/kubevault/apimachinery/releases/tag/v0.22.0)
+
+- [380e0e7d](https://github.com/kubevault/apimachinery/commit/380e0e7d) Clean up api (#110)
+
+
+
+## [kubevault/cli](https://github.com/kubevault/cli)
+
+### [v0.22.0](https://github.com/kubevault/cli/releases/tag/v0.22.0)
+
+- [52f7e854](https://github.com/kubevault/cli/commit/52f7e854) Prepare for release v0.22.0 (#208)
+
+
+
+## [kubevault/installer](https://github.com/kubevault/installer)
+
+### [v2025.5.30](https://github.com/kubevault/installer/releases/tag/v2025.5.30)
+
+- [ba60e56b](https://github.com/kubevault/installer/commit/ba60e56b) Prepare for release v2025.5.30 (#311)
+
+
+
+## [kubevault/operator](https://github.com/kubevault/operator)
+
+### [v0.22.0](https://github.com/kubevault/operator/releases/tag/v0.22.0)
+
+- [1774969e](https://github.com/kubevault/operator/commit/1774969e8) Prepare for release v0.22.0 (#138)
+- [ffbeb738](https://github.com/kubevault/operator/commit/ffbeb738f) Clean up es api (#137)
+
+
+
+## [kubevault/unsealer](https://github.com/kubevault/unsealer)
+
+### [v0.22.0](https://github.com/kubevault/unsealer/releases/tag/v0.22.0)
+
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2025.5.30
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/59
Signed-off-by: 1gtm <1gtm@appscode.com>