### PR TITLE
Prepare for release v2025.11.21

### DIFF
--- a/docs/CHANGELOG-v2025.11.21.md
+++ b/docs/CHANGELOG-v2025.11.21.md
@@ -1,0 +1,106 @@
+---
+title: Changelog | KubeVault
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubevault-v2025.11.21
+    name: Changelog-v2025.11.21
+    parent: welcome
+    weight: 20251121
+product_name: kubevault
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2025.11.21/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2025.11.21/
+---
+
+# KubeVault v2025.11.21 (2025-11-22)
+
+
+## [kubevault/apimachinery](https://github.com/kubevault/apimachinery)
+
+### [v0.23.0](https://github.com/kubevault/apimachinery/releases/tag/v0.23.0)
+
+- [97f01df8](https://github.com/kubevault/apimachinery/commit/97f01df8) Openbao -> OpenBao (#118)
+- [d110956b](https://github.com/kubevault/apimachinery/commit/d110956b) Add distribution field (#117)
+- [9ed3817b](https://github.com/kubevault/apimachinery/commit/9ed3817b) Fix Raft Backend Health Issue Check (#116)
+- [a934f8d9](https://github.com/kubevault/apimachinery/commit/a934f8d9) Test against k8s 1.34 (#115)
+- [a1658e08](https://github.com/kubevault/apimachinery/commit/a1658e08) Use Go 1.25 (#114)
+- [8692e07b](https://github.com/kubevault/apimachinery/commit/8692e07b) Test against k8s 1.33.2 (#113)
+- [db6e0908](https://github.com/kubevault/apimachinery/commit/db6e0908) Test against k8s 1.33.2 (#112)
+- [de8dc724](https://github.com/kubevault/apimachinery/commit/de8dc724) Test against k8s 1.33 (#111)
+
+
+
+## [kubevault/cli](https://github.com/kubevault/cli)
+
+### [v0.23.0](https://github.com/kubevault/cli/releases/tag/v0.23.0)
+
+- [17a9298e](https://github.com/kubevault/cli/commit/17a9298e) Prepare for release v0.23.0 (#211)
+- [dbacdc87](https://github.com/kubevault/cli/commit/dbacdc87) Use Go 1.25 (#209)
+
+
+
+## [kubevault/installer](https://github.com/kubevault/installer)
+
+### [v2025.11.21](https://github.com/kubevault/installer/releases/tag/v2025.11.21)
+
+- [3379ccf5](https://github.com/kubevault/installer/commit/3379ccf5) Prepare for release v2025.11.21 (#351)
+- [a2bcbb7f](https://github.com/kubevault/installer/commit/a2bcbb7f) Add OpenBao Version 2.4.3 (#350)
+- [d9df50d9](https://github.com/kubevault/installer/commit/d9df50d9) Update cve report (#347)
+- [818ff121](https://github.com/kubevault/installer/commit/818ff121) Update cve report (#346)
+- [e88d675b](https://github.com/kubevault/installer/commit/e88d675b) Update cve report (#345)
+- [0f9b04a7](https://github.com/kubevault/installer/commit/0f9b04a7) Update cve report (#344)
+- [f67e4d69](https://github.com/kubevault/installer/commit/f67e4d69) Update cve report (#343)
+- [3b9d98cd](https://github.com/kubevault/installer/commit/3b9d98cd) Update cve report (#342)
+- [4013f85f](https://github.com/kubevault/installer/commit/4013f85f) Update cve report (#341)
+- [30118eb2](https://github.com/kubevault/installer/commit/30118eb2) Update cve report (#340)
+- [673221f6](https://github.com/kubevault/installer/commit/673221f6) Update cve report (#339)
+- [6cb11666](https://github.com/kubevault/installer/commit/6cb11666) Update cve report (#338)
+- [96a9858f](https://github.com/kubevault/installer/commit/96a9858f) Update cve report (#337)
+- [cb1e18d2](https://github.com/kubevault/installer/commit/cb1e18d2) Update cve report (#336)
+- [fd591fc1](https://github.com/kubevault/installer/commit/fd591fc1) Update cve report (#335)
+- [557914a6](https://github.com/kubevault/installer/commit/557914a6) Test against k8s 1.34 (#334)
+- [06c88834](https://github.com/kubevault/installer/commit/06c88834) Update cve report (#333)
+- [11d005b8](https://github.com/kubevault/installer/commit/11d005b8) Update cve report (#332)
+- [5af36a6f](https://github.com/kubevault/installer/commit/5af36a6f) Update cve report (#331)
+- [ba48cd3b](https://github.com/kubevault/installer/commit/ba48cd3b) Update cve report (#330)
+- [89472c18](https://github.com/kubevault/installer/commit/89472c18) Use Go 1.25 (#329)
+- [635e6b12](https://github.com/kubevault/installer/commit/635e6b12) Test against k8s 1.33.2 (#328)
+- [20649874](https://github.com/kubevault/installer/commit/20649874) Test against k8s 1.33.2 (#327)
+- [a86ac8f1](https://github.com/kubevault/installer/commit/a86ac8f1) Update cve report (#326)
+- [254497cd](https://github.com/kubevault/installer/commit/254497cd) Update cve report (#325)
+- [18d95b77](https://github.com/kubevault/installer/commit/18d95b77) Update cve report (#324)
+- [8f4e5a9b](https://github.com/kubevault/installer/commit/8f4e5a9b) Update cve report (#323)
+- [53176a40](https://github.com/kubevault/installer/commit/53176a40) Update cve report (#322)
+- [b8ff6c9b](https://github.com/kubevault/installer/commit/b8ff6c9b) Test against k8s 1.33 (#321)
+- [31a3827e](https://github.com/kubevault/installer/commit/31a3827e) Update cve report (#320)
+- [4f655e5b](https://github.com/kubevault/installer/commit/4f655e5b) Update cve report (#319)
+- [da53639f](https://github.com/kubevault/installer/commit/da53639f) Update cve report (#318)
+- [dd39a213](https://github.com/kubevault/installer/commit/dd39a213) Update cve report (#317)
+- [236cbe6e](https://github.com/kubevault/installer/commit/236cbe6e) Update cve report (#316)
+- [9fb1a7a2](https://github.com/kubevault/installer/commit/9fb1a7a2) Update cve report (#315)
+- [87fd2781](https://github.com/kubevault/installer/commit/87fd2781) Update cve report (#314)
+
+
+
+## [kubevault/operator](https://github.com/kubevault/operator)
+
+### [v0.23.0](https://github.com/kubevault/operator/releases/tag/v0.23.0)
+
+- [93c89049](https://github.com/kubevault/operator/commit/93c890490) Prepare for release v0.23.0 (#142)
+- [ba29892f](https://github.com/kubevault/operator/commit/ba29892f3) Raft Backend Health Check Issue Fix (#141)
+- [d6bde03c](https://github.com/kubevault/operator/commit/d6bde03c1) Use Go 1.25 (#140)
+
+
+
+## [kubevault/unsealer](https://github.com/kubevault/unsealer)
+
+### [v0.23.0](https://github.com/kubevault/unsealer/releases/tag/v0.23.0)
+
+- [8c906389](https://github.com/kubevault/unsealer/commit/8c906389) Use Go 1.25 (#142)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2025.11.21
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/61
Signed-off-by: 1gtm <1gtm@appscode.com>