### PR TITLE
Prepare for release v2026.1.8-rc.0

### DIFF
--- a/docs/CHANGELOG-v2026.1.8-rc.0.md
+++ b/docs/CHANGELOG-v2026.1.8-rc.0.md
@@ -1,0 +1,90 @@
+---
+title: Changelog | KubeVault
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubevault-v2026.1.8-rc.0
+    name: Changelog-v2026.1.8-rc.0
+    parent: welcome
+    weight: 20260108
+product_name: kubevault
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2026.1.8-rc.0/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2026.1.8-rc.0/
+---
+
+# KubeVault v2026.1.8-rc.0 (2026-01-08)
+
+
+## [kubevault/apimachinery](https://github.com/kubevault/apimachinery)
+
+### [v0.24.0-rc.0](https://github.com/kubevault/apimachinery/releases/tag/v0.24.0-rc.0)
+
+- [65b12c14](https://github.com/kubevault/apimachinery/commit/65b12c14) Update deps
+- [d7d9d09f](https://github.com/kubevault/apimachinery/commit/d7d9d09f) Use k8s 1.34 client libs (#121)
+- [042c5da6](https://github.com/kubevault/apimachinery/commit/042c5da6) Test against k8s 1.35 (#120)
+- [c3bdb5a1](https://github.com/kubevault/apimachinery/commit/c3bdb5a1) Linter fix (#119)
+
+
+
+## [kubevault/cli](https://github.com/kubevault/cli)
+
+### [v0.24.0-rc.0](https://github.com/kubevault/cli/releases/tag/v0.24.0-rc.0)
+
+- [ac7d443b](https://github.com/kubevault/cli/commit/ac7d443b) Prepare for release v0.24.0-rc.0 (#214)
+- [4c703966](https://github.com/kubevault/cli/commit/4c703966) Use k8s 1.34 client libs (#213)
+- [bbd02e74](https://github.com/kubevault/cli/commit/bbd02e74) Linter fix (#212)
+
+
+
+## [kubevault/installer](https://github.com/kubevault/installer)
+
+### [v2026.1.8-rc.0](https://github.com/kubevault/installer/releases/tag/v2026.1.8-rc.0)
+
+- [0aca3303](https://github.com/kubevault/installer/commit/0aca3303) Prepare for release v2026.1.8-rc.0 (#369)
+- [7a0ae6dd](https://github.com/kubevault/installer/commit/7a0ae6dd) Update kubevault certified chart (#368)
+- [063328e6](https://github.com/kubevault/installer/commit/063328e6) Add test to kubevault chart (#367)
+- [2a270112](https://github.com/kubevault/installer/commit/2a270112) Support ubi mode for catalog chart (#366)
+- [8c7a333d](https://github.com/kubevault/installer/commit/8c7a333d) Use k8s 1.34 client libs (#365)
+- [f0bc858c](https://github.com/kubevault/installer/commit/f0bc858c) Update certified chart readme
+- [ea54c793](https://github.com/kubevault/installer/commit/ea54c793) Fix Ci workflow
+- [5ac0d332](https://github.com/kubevault/installer/commit/5ac0d332) Generate certified and certified-crds charts (#363)
+- [335cda51](https://github.com/kubevault/installer/commit/335cda51) Test against k8s 1.35 (#362)
+- [6098cfc9](https://github.com/kubevault/installer/commit/6098cfc9) Fix operator.ubi and catalog.ubi templates
+- [1c8dbf55](https://github.com/kubevault/installer/commit/1c8dbf55) Test for ubi images (#360)
+- [ded44442](https://github.com/kubevault/installer/commit/ded44442) Add OpenShift support (#359)
+- [140656b0](https://github.com/kubevault/installer/commit/140656b0) Use ghcr.io/kubevault/vault-unsealer
+- [cd4689b5](https://github.com/kubevault/installer/commit/cd4689b5) Update cve report (#358)
+- [892545b5](https://github.com/kubevault/installer/commit/892545b5) Update cve report (#356)
+- [e09bbcbf](https://github.com/kubevault/installer/commit/e09bbcbf) Use golangci-lint 2.x (#357)
+- [ee2f887b](https://github.com/kubevault/installer/commit/ee2f887b) Update cve report (#355)
+
+
+
+## [kubevault/operator](https://github.com/kubevault/operator)
+
+### [v0.24.0-rc.0](https://github.com/kubevault/operator/releases/tag/v0.24.0-rc.0)
+
+- [06822f36](https://github.com/kubevault/operator/commit/06822f36e) Prepare for release v0.24.0-rc.0 (#149)
+- [cd1804bd](https://github.com/kubevault/operator/commit/cd1804bd3) Use k8s 1.34 client libs (#148)
+- [b204a5c6](https://github.com/kubevault/operator/commit/b204a5c64) Fix makefile indentation (#147)
+- [816fa4d1](https://github.com/kubevault/operator/commit/816fa4d1a) Publish Image for Redhat software certification (#145)
+- [00403e68](https://github.com/kubevault/operator/commit/00403e685) Build ubi image (#144)
+- [fbd8a3c0](https://github.com/kubevault/operator/commit/fbd8a3c07) Linter fix (#143)
+
+
+
+## [kubevault/unsealer](https://github.com/kubevault/unsealer)
+
+### [v0.24.0-rc.0](https://github.com/kubevault/unsealer/releases/tag/v0.24.0-rc.0)
+
+- [aac7ce6c](https://github.com/kubevault/unsealer/commit/aac7ce6c) Use k8s 1.34 client libs (#144)
+- [46d1f17f](https://github.com/kubevault/unsealer/commit/46d1f17f) Build ubi image
+- [70e103a9](https://github.com/kubevault/unsealer/commit/70e103a9) Update deps
+- [8a708cc9](https://github.com/kubevault/unsealer/commit/8a708cc9) Linter fix (#143)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2026.1.8-rc.0
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/63
Signed-off-by: 1gtm <1gtm@appscode.com>