### PR TITLE
Prepare for release v2026.2.27

### DIFF
--- a/docs/CHANGELOG-v2026.2.27.md
+++ b/docs/CHANGELOG-v2026.2.27.md
@@ -1,0 +1,116 @@
+---
+title: Changelog | KubeVault
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubevault-v2026.2.27
+    name: Changelog-v2026.2.27
+    parent: welcome
+    weight: 20260227
+product_name: kubevault
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2026.2.27/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2026.2.27/
+---
+
+# KubeVault v2026.2.27 (2026-02-25)
+
+
+## [kubevault/apimachinery](https://github.com/kubevault/apimachinery)
+
+### [v0.24.0](https://github.com/kubevault/apimachinery/releases/tag/v0.24.0)
+
+- [f87d19a3](https://github.com/kubevault/apimachinery/commit/f87d19a3) Report features in site info
+- [b6894698](https://github.com/kubevault/apimachinery/commit/b6894698) Fix CVE (#124)
+- [3d7b4914](https://github.com/kubevault/apimachinery/commit/3d7b4914) Add Namespace Support (MySQL)
+- [65b12c14](https://github.com/kubevault/apimachinery/commit/65b12c14) Update deps
+- [d7d9d09f](https://github.com/kubevault/apimachinery/commit/d7d9d09f) Use k8s 1.34 client libs (#121)
+- [042c5da6](https://github.com/kubevault/apimachinery/commit/042c5da6) Test against k8s 1.35 (#120)
+- [c3bdb5a1](https://github.com/kubevault/apimachinery/commit/c3bdb5a1) Linter fix (#119)
+
+
+
+## [kubevault/cli](https://github.com/kubevault/cli)
+
+### [v0.24.0](https://github.com/kubevault/cli/releases/tag/v0.24.0)
+
+- [9c9278a9](https://github.com/kubevault/cli/commit/9c9278a9) Prepare for release v0.24.0 (#216)
+- [ac7d443b](https://github.com/kubevault/cli/commit/ac7d443b) Prepare for release v0.24.0-rc.0 (#214)
+- [4c703966](https://github.com/kubevault/cli/commit/4c703966) Use k8s 1.34 client libs (#213)
+- [bbd02e74](https://github.com/kubevault/cli/commit/bbd02e74) Linter fix (#212)
+
+
+
+## [kubevault/installer](https://github.com/kubevault/installer)
+
+### [v2026.2.27](https://github.com/kubevault/installer/releases/tag/v2026.2.27)
+
+- [dc22a8cf](https://github.com/kubevault/installer/commit/dc22a8cf) Prepare for release v2026.2.27 (#396)
+- [0d183094](https://github.com/kubevault/installer/commit/0d183094) Update cve report (#395)
+- [bdcb522d](https://github.com/kubevault/installer/commit/bdcb522d) Update cve report (#394)
+- [a3c219b9](https://github.com/kubevault/installer/commit/a3c219b9) Add permission to report cluster features (#393)
+- [73f9f08d](https://github.com/kubevault/installer/commit/73f9f08d) Update cve report (#392)
+- [5556c096](https://github.com/kubevault/installer/commit/5556c096) Add storageClass list permission for audit (#391)
+- [fbbd8a0c](https://github.com/kubevault/installer/commit/fbbd8a0c) Update cve report (#390)
+- [45646776](https://github.com/kubevault/installer/commit/45646776) Update cve report (#389)
+- [d932ef6a](https://github.com/kubevault/installer/commit/d932ef6a) Update cve report (#388)
+- [aad22173](https://github.com/kubevault/installer/commit/aad22173) Update cve report (#387)
+- [776d2e97](https://github.com/kubevault/installer/commit/776d2e97) Update cve report (#385)
+- [5dbef9e9](https://github.com/kubevault/installer/commit/5dbef9e9) Update chart version for EKS (#386)
+- [f050f8d7](https://github.com/kubevault/installer/commit/f050f8d7) Update cve report (#384)
+- [48abccc3](https://github.com/kubevault/installer/commit/48abccc3) Update cve report (#383)
+- [4c01697b](https://github.com/kubevault/installer/commit/4c01697b) Update cve report (#382)
+- [f35f34ac](https://github.com/kubevault/installer/commit/f35f34ac) Update cve report (#381)
+- [a2e339da](https://github.com/kubevault/installer/commit/a2e339da) Update cve report (#380)
+- [e28c5699](https://github.com/kubevault/installer/commit/e28c5699) Update cve report (#379)
+- [44af4759](https://github.com/kubevault/installer/commit/44af4759) Update certified charts (#378)
+- [59cf07b3](https://github.com/kubevault/installer/commit/59cf07b3) Add values schema (#376)
+- [f91eec91](https://github.com/kubevault/installer/commit/f91eec91) Update cve report (#375)
+- [f8c98cd5](https://github.com/kubevault/installer/commit/f8c98cd5) Use strict semver version for certified charts (#374)
+- [89d78343](https://github.com/kubevault/installer/commit/89d78343) Update cve report (#373)
+- [93eba10f](https://github.com/kubevault/installer/commit/93eba10f) Use kubectl 1.34 (#372)
+- [00cd7518](https://github.com/kubevault/installer/commit/00cd7518) Update cve report (#371)
+- [63f97fb3](https://github.com/kubevault/installer/commit/63f97fb3) Update cve report (#370)
+- [fa9d1350](https://github.com/kubevault/installer/commit/fa9d1350) Update cve report (#364)
+- [0aca3303](https://github.com/kubevault/installer/commit/0aca3303) Prepare for release v2026.1.8-rc.0 (#369)
+- [7a0ae6dd](https://github.com/kubevault/installer/commit/7a0ae6dd) Update kubevault certified chart (#368)
+- [063328e6](https://github.com/kubevault/installer/commit/063328e6) Add test to kubevault chart (#367)
+- [2a270112](https://github.com/kubevault/installer/commit/2a270112) Support ubi mode for catalog chart (#366)
+- [8c7a333d](https://github.com/kubevault/installer/commit/8c7a333d) Use k8s 1.34 client libs (#365)
+- [f0bc858c](https://github.com/kubevault/installer/commit/f0bc858c) Update certified chart readme
+- [ea54c793](https://github.com/kubevault/installer/commit/ea54c793) Fix Ci workflow
+- [5ac0d332](https://github.com/kubevault/installer/commit/5ac0d332) Generate certified and certified-crds charts (#363)
+- [335cda51](https://github.com/kubevault/installer/commit/335cda51) Test against k8s 1.35 (#362)
+- [6098cfc9](https://github.com/kubevault/installer/commit/6098cfc9) Fix operator.ubi and catalog.ubi templates
+- [1c8dbf55](https://github.com/kubevault/installer/commit/1c8dbf55) Test for ubi images (#360)
+- [ded44442](https://github.com/kubevault/installer/commit/ded44442) Add OpenShift support (#359)
+- [140656b0](https://github.com/kubevault/installer/commit/140656b0) Use ghcr.io/kubevault/vault-unsealer
+- [cd4689b5](https://github.com/kubevault/installer/commit/cd4689b5) Update cve report (#358)
+- [892545b5](https://github.com/kubevault/installer/commit/892545b5) Update cve report (#356)
+- [e09bbcbf](https://github.com/kubevault/installer/commit/e09bbcbf) Use golangci-lint 2.x (#357)
+- [ee2f887b](https://github.com/kubevault/installer/commit/ee2f887b) Update cve report (#355)
+
+
+
+## [kubevault/operator](https://github.com/kubevault/operator)
+
+### [v0.24.0](https://github.com/kubevault/operator/releases/tag/v0.24.0)
+
+
+
+
+## [kubevault/unsealer](https://github.com/kubevault/unsealer)
+
+### [v0.24.0](https://github.com/kubevault/unsealer/releases/tag/v0.24.0)
+
+- [17eb23ab](https://github.com/kubevault/unsealer/commit/17eb23ab) Remove linux/arm build (#145)
+- [aac7ce6c](https://github.com/kubevault/unsealer/commit/aac7ce6c) Use k8s 1.34 client libs (#144)
+- [46d1f17f](https://github.com/kubevault/unsealer/commit/46d1f17f) Build ubi image
+- [70e103a9](https://github.com/kubevault/unsealer/commit/70e103a9) Update deps
+- [8a708cc9](https://github.com/kubevault/unsealer/commit/8a708cc9) Linter fix (#143)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2026.2.27
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/64
Signed-off-by: 1gtm <1gtm@appscode.com>