### PR TITLE
Use node-version: '22' in setup-node steps

### DIFF
--- a/.github/workflows/preview-website.yml
+++ b/.github/workflows/preview-website.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install yq
         run: |


### PR DESCRIPTION
Standardize Node.js version in setup-node steps to '22'.