### PR TITLE
Prepare for release v2026.5.18-rc.1

### DIFF
--- a/docs/CHANGELOG-v2026.5.18-rc.1.md
+++ b/docs/CHANGELOG-v2026.5.18-rc.1.md
@@ -1,0 +1,72 @@
+---
+title: Changelog | KubeVault
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubevault-v2026.5.18-rc.1
+    name: Changelog-v2026.5.18-rc.1
+    parent: welcome
+    weight: 20260518
+product_name: kubevault
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2026.5.18-rc.1/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2026.5.18-rc.1/
+---
+
+# KubeVault v2026.5.18-rc.1 (2026-05-18)
+
+
+## [kubevault/apimachinery](https://github.com/kubevault/apimachinery)
+
+### [v0.25.0-rc.1](https://github.com/kubevault/apimachinery/releases/tag/v0.25.0-rc.1)
+
+- [d03a6c7c](https://github.com/kubevault/apimachinery/commit/d03a6c7c) Add AGENTS.md (#133)
+- [075c9c56](https://github.com/kubevault/apimachinery/commit/075c9c56) Add 1gtm-app[bot] to kodiak auto_approve_usernames (#132)
+
+
+
+## [kubevault/cli](https://github.com/kubevault/cli)
+
+### [v0.25.0-rc.1](https://github.com/kubevault/cli/releases/tag/v0.25.0-rc.1)
+
+- [61d31fd8](https://github.com/kubevault/cli/commit/61d31fd8) Prepare for release v0.25.0-rc.1 (#227)
+- [ca45ac56](https://github.com/kubevault/cli/commit/ca45ac56) Add AGENTS.md (#226)
+- [4ed7b9d5](https://github.com/kubevault/cli/commit/4ed7b9d5) Harden CI workflows (#225)
+
+
+
+## [kubevault/installer](https://github.com/kubevault/installer)
+
+### [v2026.5.18-rc.1](https://github.com/kubevault/installer/releases/tag/v2026.5.18-rc.1)
+
+- [ad0ee4fa](https://github.com/kubevault/installer/commit/ad0ee4fa) Prepare for release v2026.5.18-rc.1 (#443)
+- [14ccba08](https://github.com/kubevault/installer/commit/14ccba08) Fix release tracker workflow
+- [4e8a272d](https://github.com/kubevault/installer/commit/4e8a272d) Add AGENTS.md (#442)
+- [80830cdf](https://github.com/kubevault/installer/commit/80830cdf) publish-oci.yml: replace GHCRX app token with LGTM_GITHUB_TOKEN (#441)
+- [a7636bb6](https://github.com/kubevault/installer/commit/a7636bb6) Remove bzr install from workflows (#440)
+
+
+
+## [kubevault/operator](https://github.com/kubevault/operator)
+
+### [v0.25.0-rc.1](https://github.com/kubevault/operator/releases/tag/v0.25.0-rc.1)
+
+- [9418ad4b](https://github.com/kubevault/operator/commit/9418ad4b7) Fix release tracker workflow
+- [593dd1ee](https://github.com/kubevault/operator/commit/593dd1ee6) Prepare for release v0.25.0-rc.1 (#174)
+- [ecd00441](https://github.com/kubevault/operator/commit/ecd004413) Add AGENTS.md (#173)
+- [eb6ba157](https://github.com/kubevault/operator/commit/eb6ba1574) Pin git user to 1gtm in update-crds/update-docs workflows (#172)
+
+
+
+## [kubevault/unsealer](https://github.com/kubevault/unsealer)
+
+### [v0.25.0-rc.1](https://github.com/kubevault/unsealer/releases/tag/v0.25.0-rc.1)
+
+- [aa6de2ae](https://github.com/kubevault/unsealer/commit/aa6de2ae) Add AGENTS.md (#158)
+- [a7096a5a](https://github.com/kubevault/unsealer/commit/a7096a5a) Pin git user to 1gtm in update-crds/update-docs workflows (#157)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2026.5.18-rc.1
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/69
Signed-off-by: 1gtm <1gtm@appscode.com>