### PR TITLE
docs/guides: add IBM Db2 secret engine guide

### DIFF
--- a/docs/concepts/secret-engine-crds/database-secret-engine/db2.md
+++ b/docs/concepts/secret-engine-crds/database-secret-engine/db2.md
@@ -1,0 +1,105 @@
+---
+title: DB2Role | Vault Secret Engine
+menu:
+  docs_{{ .version }}:
+    identifier: db2role-database-crds
+    name: DB2Role
+    parent: database-crds-concepts
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: concepts
+---
+
+> New to KubeVault? Please start [here](/docs/concepts/README.md).
+
+# DB2Role
+
+## What is DB2Role
+
+A `DB2Role` is a Kubernetes `CustomResourceDefinition` (CRD) which allows a user to create a database secret engine role in a Kubernetes native way.
+
+When a `DB2Role` is created, the KubeVault operator creates a [role](https://www.vaultproject.io/api/secret/databases/index.html#create-role) according to specification.
+If the user deletes the `DB2Role` CRD, then the respective role will also be deleted from Vault.
+
+> Note: The `db2-database-plugin` shipped in [openbao/openbao#19](https://github.com/openbao/openbao/pull/19) is **static-credentials-only**. It does NOT implement dynamic credential issuance (`NewUser`) — IBM Db2 user accounts must be provisioned out-of-band against the underlying OS / LDAP realm that Db2 authenticates against. The `DB2Role` CRD therefore only attaches role metadata (`db_name`, `default_ttl`, `max_ttl`) to a pre-existing Db2 principal. Operators wire up password rotation by calling `bao write database/static-roles/<role>` against this metadata; from then on OpenBao rotates the principal's password on the configured cadence and exposes the current credential at `database/static-creds/<role>`.
+
+## DB2Role CRD Specification
+
+Like any official Kubernetes resource, a `DB2Role` object has `TypeMeta`, `ObjectMeta`, `Spec` and `Status` sections.
+
+A sample `DB2Role` object is shown below:
+
+```yaml
+apiVersion: engine.kubevault.com/v1alpha1
+kind: DB2Role
+metadata:
+  name: db2-role
+  namespace: demo
+spec:
+  secretEngineRef:
+    name: vault-app
+  defaultTTL: "1h"
+  maxTTL: "24h"
+status:
+  observedGeneration: 1
+  phase: Success
+```
+
+> Note: To resolve the naming conflict, name of the role in Vault will follow this format: `k8s.{clusterName}.{metadata.namespace}.{metadata.name}`
+
+Here, we are going to describe the various sections of the `DB2Role` CRD.
+
+### DB2Role Spec
+
+DB2Role `spec` contains information that is necessary for creating a database role.
+
+```yaml
+spec:
+  secretEngineRef:
+    name: <vault-appbinding-name>
+  defaultTTL: <default-ttl>
+  maxTTL: <max-ttl>
+```
+
+DB2Role spec has the following fields:
+
+#### spec.secretEngineRef
+
+`spec.secretEngineRef` is a `required` field that specifies the name of a `SecretEngine`.
+
+```yaml
+spec:
+  secretEngineRef:
+    name: db2-secret-engine
+```
+
+#### spec.defaultTTL
+
+`spec.defaultTTL` is an `optional` field that specifies the TTL for the leases associated with this role.
+Accepts time suffixed strings ("1h") or an integer number of seconds. Defaults to system/engine default TTL time.
+
+```yaml
+spec:
+  defaultTTL: "1h"
+```
+
+#### spec.maxTTL
+
+`spec.maxTTL` is an `optional` field that specifies the maximum TTL for the leases associated with this role.
+Accepts time suffixed strings ("1h") or an integer number of seconds. Defaults to system/engine default TTL time.
+
+```yaml
+spec:
+  maxTTL: "1h"
+```
+
+### DB2Role Status
+
+`status` shows the status of the DB2Role. It is managed by the KubeVault operator. It contains the following fields:
+
+- `observedGeneration`: Specifies the most recent generation observed for this resource. It corresponds to the resource's generation,
+    which is updated on mutation by the API Server.
+
+- `phase`: Indicates whether the role successfully applied to Vault or not.
+
+- `conditions` : Represent observations of a DB2Role.

--- a/docs/concepts/secret-engine-crds/database-secret-engine/db2.md
+++ b/docs/concepts/secret-engine-crds/database-secret-engine/db2.md
@@ -103,3 +103,13 @@ spec:
 - `phase`: Indicates whether the role successfully applied to Vault or not.
 
 - `conditions` : Represent observations of a DB2Role.
+
+## Namespace inheritance (tenant isolation)
+
+A `DB2Role` never sets or resolves an OpenBao namespace itself. It always inherits the
+**effective namespace** of the `SecretEngine` it references via `spec.secretEngineRef`
+(`SecretEngine.status.effectiveNamespace`) — empty for root, or the tenant's OpenBao
+namespace once [tenant isolation](/docs/guides/tenant-isolation/overview.md) has placed
+that engine in one. Every credential this role issues, and every revocation
+(`SecretAccessRequest`), is scoped to that same namespace automatically — no
+`DB2Role`-level configuration is needed.

--- a/docs/examples/guides/secret-engines/db2/pod.yaml
+++ b/docs/examples/guides/secret-engines/db2/pod.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-app
+  namespace: demo
+spec:
+  serviceAccountName: test-user-account
+  containers:
+    - image: jweissig/app:0.0.1
+      name: demo-app
+      imagePullPolicy: Always
+      volumeMounts:
+        - name: secrets-store-inline
+          mountPath: "/secrets-store/db2-creds"
+          readOnly: true
+  volumes:
+    - name: secrets-store-inline
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: "vault-db-provider"

--- a/docs/examples/guides/secret-engines/db2/secretengine.yaml
+++ b/docs/examples/guides/secret-engines/db2/secretengine.yaml
@@ -1,0 +1,15 @@
+apiVersion: engine.kubevault.com/v1alpha1
+kind: SecretEngine
+metadata:
+  name: db2-engine
+  namespace: demo
+spec:
+  vaultRef:
+    name: vault
+  db2:
+    databaseRef:
+      name: db2
+      namespace: demo
+    pluginName: db2-database-plugin
+    allowedRoles:
+    - "*"

--- a/docs/examples/guides/secret-engines/db2/secretenginerole.yaml
+++ b/docs/examples/guides/secret-engines/db2/secretenginerole.yaml
@@ -1,0 +1,10 @@
+apiVersion: engine.kubevault.com/v1alpha1
+kind: DB2Role
+metadata:
+  name: db2-app-role
+  namespace: demo
+spec:
+  secretEngineRef:
+    name: db2-engine
+  defaultTTL: 24h
+  maxTTL: 168h

--- a/docs/examples/guides/secret-engines/db2/secretproviderclass.yaml
+++ b/docs/examples/guides/secret-engines/db2/secretproviderclass.yaml
@@ -1,0 +1,17 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: vault-db-provider
+  namespace: demo
+spec:
+  provider: vault
+  parameters:
+    vaultAddress: "http://vault.demo:8200"
+    roleName: "k8s.-.demo.db2-app-role"
+    objects: |
+      - objectName: "db2-creds-username"
+        secretPath: "your-database-path/static-creds/k8s.-.demo.db2-app-role"
+        secretKey: "username"
+      - objectName: "db2-creds-password"
+        secretPath: "your-database-path/static-creds/k8s.-.demo.db2-app-role"
+        secretKey: "password"

--- a/docs/examples/guides/secret-engines/db2/secretrolebinding.yaml
+++ b/docs/examples/guides/secret-engines/db2/secretrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: engine.kubevault.com/v1alpha1
+kind: SecretRoleBinding
+metadata:
+  name: secret-role-binding
+  namespace: demo
+spec:
+  roles:
+    - kind: DB2Role
+      name: db2-app-role
+  subjects:
+    - kind: ServiceAccount
+      name: test-user-account
+      namespace: demo

--- a/docs/examples/guides/secret-engines/db2/serviceaccount.yaml
+++ b/docs/examples/guides/secret-engines/db2/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-user-account
+  namespace: demo

--- a/docs/guides/hub-spoke/deploy-hub-spoke.md
+++ b/docs/guides/hub-spoke/deploy-hub-spoke.md
@@ -239,7 +239,7 @@ spec:
 
 Because the AppBinding's `deploymentMode` is `RemoteRelay`, the SecretEngine controller configures the hub mount with `plugin_name: remote-postgres-plugin` and `spoke_name: cluster-1`. The hub proxies every credential operation to the spoke relay, which runs the real `postgresql-database-plugin` in-process against the spoke-local database.
 
-Postgres, MySQL, MariaDB, Redis, and Valkey are supported through the spoke relay. MongoDB and Elasticsearch are not; a SecretEngine for those against a `RemoteRelay` AppBinding is rejected on apply by the validating webhook.
+Postgres, MySQL, MariaDB, Redis, Valkey, and DB2 are supported through the spoke relay. MongoDB and Elasticsearch are not; a SecretEngine for those against a `RemoteRelay` AppBinding is rejected on apply by the validating webhook.
 
 Request credentials the usual way with a `SecretAccessRequest`; see the [secret engine guides](/docs/guides/secret-engines/postgres/overview.md).
 

--- a/docs/guides/secret-engines/db2/_index.md
+++ b/docs/guides/secret-engines/db2/_index.md
@@ -1,0 +1,10 @@
+---
+title: IBM Db2 | Vault Secret Engine
+menu:
+  docs_{{ .version }}:
+    identifier: db2-secret-engines
+    name: IBM Db2
+    parent: secret-engines-guides
+    weight: 150
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/secret-engines/db2/csi-driver.md
+++ b/docs/guides/secret-engines/db2/csi-driver.md
@@ -1,0 +1,253 @@
+---
+title: Mount IBM Db2 Secrets using CSI Driver
+menu:
+  docs_{{ .version }}:
+    identifier: csi-driver-db2
+    name: CSI Driver
+    parent: db2-secret-engines
+    weight: 15
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+# Mount IBM Db2 Secrets using CSI Driver
+
+## Kubernetes Secrets Store CSI Driver
+
+Secrets Store CSI driver for Kubernetes secrets - Integrates secrets stores with Kubernetes via a [Container Storage Interface (CSI)](https://kubernetes-csi.github.io/docs/) volume.
+
+The Secrets Store CSI driver `secrets-store.csi.k8s.io` allows Kubernetes to mount multiple secrets, keys, and certs stored in enterprise-grade external secrets stores into their pods as a volume. Once the Volume is attached, the data in it is mounted into the container's file system.
+
+![Secrets-store CSI architecture](/docs/guides/secret-engines/csi_architecture.svg)
+
+When the `Pod` is created through the K8s API, it's scheduled on to a node. The `kubelet` process on the node looks at the pod spec & see if there's any `volumeMount` request. The `kubelet` issues an `RPC` to the `CSI driver` to mount the volume. The `CSI driver` creates & mounts `tmpfs` into the pod. Then the `CSI driver` issues a request to the `Provider`. The provider talks to the external secrets store to fetch the secrets & write them to the pod volume as files. At this point, volume is successfully mounted & the pod starts running.
+
+You can read more about the Kubernetes Secrets Store CSI Driver [here](https://secrets-store-csi-driver.sigs.k8s.io/).
+
+> Note: The `db2-database-plugin` is **static-credentials-only** — it does not issue dynamic credentials. The CSI flow described below therefore reads from `database/static-creds/<role>`, which exposes a username/password pair that OpenBao rotates on the cadence configured by the operator via `bao write database/static-roles/<role>`. The `DB2Role` CRD is a metadata binding only; the underlying Db2 principal must already exist.
+
+## Consuming Secrets
+
+At first, you need to have a Kubernetes 1.16 or later cluster, and the kubectl command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/). To check the version of your cluster, run:
+
+```bash
+$ kubectl version --short
+Client Version: v1.21.2
+Server Version: v1.21.1
+```
+
+Before you begin:
+
+- Install KubeVault operator in your cluster from [here](/docs/setup/README.md).
+- Install Secrets Store CSI driver for Kubernetes secrets in your cluster from [here](https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation.html).
+- Install Vault Specific CSI provider from [here](https://github.com/hashicorp/vault-csi-provider)
+
+To keep things isolated, we are going to use a separate namespace called `demo` throughout this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> Note: YAML files used in this tutorial stored in [examples](/docs/examples/guides/secret-engines/db2) folder in GitHub repository [KubeVault/docs](https://github.com/kubevault/kubevault)
+
+## Vault Server
+
+If you don't have a Vault Server, you can deploy it by using the KubeVault operator.
+
+- [Deploy Vault Server](/docs/guides/vault-server/vault-server.md)
+
+The KubeVault operator can manage policies and secret engines of Vault servers which are not provisioned by the KubeVault operator. You need to configure both the Vault server and the cluster so that the KubeVault operator can communicate with your Vault server.
+
+- [Configure cluster and Vault server](/docs/guides/vault-server/external-vault-sever.md#configuration)
+
+Now, we have the [AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md) that contains connection and authentication information about the Vault server. And we also have the service account that the Vault server can authenticate.
+
+```bash
+$ kubectl get appbinding -n demo
+NAME    AGE
+vault   50m
+```
+
+## Enable & Configure IBM Db2 SecretEngine
+
+### Enable IBM Db2 SecretEngine
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/db2/secretengine.yaml
+secretengine.engine.kubevault.com/db2-engine created
+```
+
+### Create DB2Role
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/db2/secretenginerole.yaml
+db2role.engine.kubevault.com/db2-app-role created
+```
+
+Let's say pod's service account name is `test-user-account` located in `demo` namespace. We need to create a [VaultPolicy](/docs/concepts/policy-crds/vaultpolicy.md) and a [VaultPolicyBinding](/docs/concepts/policy-crds/vaultpolicybinding.md) so that the pod has access to read secrets from the Vault server.
+
+### Create Service Account for Pod
+
+Let's create the service account `test-user-account` which will be used in VaultPolicyBinding.
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-user-account
+  namespace: demo
+```
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/db2/serviceaccount.yaml
+serviceaccount/test-user-account created
+```
+
+### Create SecretRoleBinding for Pod's Service Account
+
+SecretRoleBinding will create VaultPolicy and VaultPolicyBinding inside vault.
+When a VaultPolicyBinding object is created, the KubeVault operator creates an auth role in the Vault server. The role name is generated by the following naming format: `k8s.(clusterName or -).namespace.name`. Here, it is `k8s.-.demo.db2-app-role`.
+
+For static-only plugins the operator-rendered policy grants read access on both `database/creds/<role>` and `database/static-creds/<role>` paths, so the SecretRoleBinding manifest itself is unchanged from the dynamic-plugin flow — only the path the consumer reads from differs.
+
+```yaml
+apiVersion: engine.kubevault.com/v1alpha1
+kind: SecretRoleBinding
+metadata:
+  name: secret-role-binding
+  namespace: demo
+spec:
+  roles:
+    - kind: DB2Role
+      name: db2-app-role
+  subjects:
+    - kind: ServiceAccount
+      name: test-user-account
+      namespace: demo
+```
+
+Let's create SecretRoleBinding:
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/db2/secretrolebinding.yaml
+secretrolebinding.engine.kubevault.com/secret-role-binding created
+```
+
+Check if the VaultPolicy and the VaultPolicyBinding are successfully registered to the Vault server:
+
+```bash
+$ kubectl get vaultpolicy -n demo
+NAME                                         STATUS    AGE
+srb-demo-secret-role-binding                 Success   8s
+
+$ kubectl get vaultpolicybinding -n demo
+NAME                                            STATUS    AGE
+srb-demo-secret-role-binding                    Success   10s
+```
+
+## Mount secrets into a Kubernetes pod
+
+So, we can create `SecretProviderClass` now. You can read more about `SecretProviderClass` [here](https://secrets-store-csi-driver.sigs.k8s.io/concepts.html#secretproviderclass).
+
+### Create SecretProviderClass
+
+Create `SecretProviderClass` object with the following content. Because the plugin is static-only, the `secretPath` points at `database/static-creds/<role>` rather than `database/creds/<role>`:
+
+```yaml
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: vault-db-provider
+  namespace: demo
+spec:
+  provider: vault
+  parameters:
+    vaultAddress: "http://vault.demo:8200"
+    roleName: "k8s.-.demo.db2-app-role"
+    objects: |
+      - objectName: "db2-creds-username"
+        secretPath: "your-database-path/static-creds/k8s.-.demo.db2-app-role"
+        secretKey: "username"
+      - objectName: "db2-creds-password"
+        secretPath: "your-database-path/static-creds/k8s.-.demo.db2-app-role"
+        secretKey: "password"
+```
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/db2/secretproviderclass.yaml
+secretproviderclass.secrets-store.csi.x-k8s.io/vault-db-provider created
+```
+NOTE: The `SecretProviderClass` needs to be created in the same namespace as the pod.
+
+### Create Pod
+
+Now we can create a `Pod` to consume the `IBM Db2` secrets. When the `Pod` is created, the `Provider` fetches the secret and writes them to Pod's volume as files. At this point, the volume is successfully mounted and the `Pod` starts running.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-app
+  namespace: demo
+spec:
+  serviceAccountName: test-user-account
+  containers:
+    - image: jweissig/app:0.0.1
+      name: demo-app
+      imagePullPolicy: Always
+      volumeMounts:
+        - name: secrets-store-inline
+          mountPath: "/secrets-store/db2-creds"
+          readOnly: true
+  volumes:
+    - name: secrets-store-inline
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: "vault-db-provider"
+```
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/db2/pod.yaml
+pod/demo-app created
+```
+
+## Test & Verify
+
+Check if the Pod is running successfully, by running:
+
+```bash
+$ kubectl get pods -n demo
+NAME                       READY   STATUS    RESTARTS   AGE
+demo-app                   1/1     Running   0          11s
+```
+
+### Verify Secret
+
+If the Pod is running successfully, then check inside the app container by running
+
+```bash
+$ kubectl exec -it -n demo pod/demo-app -- /bin/sh
+/ # ls /secrets-store/db2-creds
+db2-creds-password  db2-creds-username
+
+/ # cat /secrets-store/db2-creds/db2-creds-username
+db2inst1
+
+/ # cat /secrets-store/db2-creds/db2-creds-password
+TAu2Zvg1WYE07W8Uf-nW
+
+/ # exit
+```
+
+So, we can see that the rotated static credentials for the IBM Db2 principal are mounted into the pod, where each secret key is mounted as a file and the value is the content of that file. As OpenBao rotates the principal on the configured cadence, the CSI driver will refresh the mounted files in place.
+
+## Cleaning up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+$ kubectl delete ns demo
+namespace "demo" deleted
+```

--- a/docs/guides/secret-engines/db2/overview.md
+++ b/docs/guides/secret-engines/db2/overview.md
@@ -1,0 +1,165 @@
+---
+title: Manage IBM Db2 credentials using the KubeVault operator
+menu:
+  docs_{{ .version }}:
+    identifier: overview-db2
+    name: Overview
+    parent: db2-secret-engines
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeVault? Please start [here](/docs/concepts/README.md).
+
+# Manage IBM Db2 credentials using the KubeVault operator
+
+OpenBao's [`db2-database-plugin`](https://github.com/sigilr/openbao/pull/19) is a **static-credentials-only** database plugin. There is no pure-Go Db2 driver and most production deployments delegate user management to the OS or LDAP, so the plugin does not support dynamic `bao read database/creds/<role>` calls. Instead, KubeVault treats Db2 like a static-credentials engine: you provision the Db2 principal out of band, then use [`DB2Role`](/docs/concepts/secret-engine-crds/database-secret-engine/db2role.md) to attach rotation metadata to that pre-existing principal.
+
+The same CRD shape is used both for the in-process `db2-database-plugin` and for the hub-spoke `remote-db2-plugin`; the difference is whether the [Vault AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md) referenced by `SecretEngine.spec.vaultRef` is marked `deploymentMode: RemoteAgent` (then the SecretEngine controller rewrites `plugin_name` to `remote-db2-plugin` and attaches `spoke_name`).
+
+You need to be familiar with the following CRDs:
+
+- [AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md)
+- [SecretEngine](/docs/concepts/secret-engine-crds/secretengine.md)
+- [DB2Role](/docs/concepts/secret-engine-crds/database-secret-engine/db2role.md)
+
+## Before you begin
+
+- Install KubeVault operator in your cluster from [here](/docs/setup/README.md).
+- Provision a Db2 deployment that exposes the [Db2 REST API](https://www.ibm.com/docs/en/db2/11.5?topic=apis-rest) (`/dbapi/v4/host_status`). The plugin only uses this endpoint for an optional reachability check.
+- Provision a Db2 principal (via `AUTH_NATIVE`, OS, or LDAP) for each role you want to rotate. KubeVault will not create the principal.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+## Vault Server
+
+Deploy a Vault Server using the KubeVault operator: [Deploy Vault Server](/docs/guides/vault-server/vault-server.md). The KubeVault operator will create an [AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md) wiring up Kubernetes auth.
+
+```bash
+$ kubectl get appbinding -n demo vault -o yaml
+```
+
+## AppBinding for Db2
+
+Create an `AppBinding` pointing at the Db2 REST endpoint. The username/password Secret (if present) feeds the plugin's optional Basic Auth healthcheck.
+
+```yaml
+apiVersion: appcatalog.appscode.com/v1alpha1
+kind: AppBinding
+metadata:
+  name: db2
+  namespace: demo
+spec:
+  clientConfig:
+    url: http://db2-dbapi.demo.svc:50000
+  secret:
+    name: db2-cred
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db2-cred
+  namespace: demo
+type: kubernetes.io/basic-auth
+stringData:
+  username: bao
+  password: <strong-password>
+```
+
+## Enable and configure the Db2 secret engine
+
+```yaml
+apiVersion: engine.kubevault.com/v1alpha1
+kind: SecretEngine
+metadata:
+  name: db2-engine
+  namespace: demo
+spec:
+  vaultRef:
+    name: vault
+  db2:
+    databaseRef:
+      name: db2
+      namespace: demo
+    pluginName: db2-database-plugin
+    allowedRoles:
+    - "*"
+```
+
+Apply and wait for the engine to land:
+
+```bash
+$ kubectl apply -f db2-secret-engine.yaml
+secretengine.engine.kubevault.com/db2-engine created
+$ kubectl get secretengines -n demo
+NAME         STATUS    AGE
+db2-engine   Success   10s
+```
+
+Behind the scenes the KubeVault operator writes:
+
+```
+bao write database/config/k8s.<cluster>.demo.db2 \
+    plugin_name=db2-database-plugin \
+    url=http://db2-dbapi.demo.svc:50000 \
+    username=bao \
+    password=<strong-password> \
+    allowed_roles="*"
+```
+
+When the referenced AppBinding is `deploymentMode: RemoteAgent`, the operator substitutes `plugin_name=remote-db2-plugin` and adds `spoke_name=<spoke>` so the hub forwards the call to the matching `bao agent run` daemon. See the [remote-db-plugin DESIGN](https://github.com/sigilr/openbao/blob/db-plugin-db2/plugins/database/remote-db-plugin/DESIGN.md) for the hub-spoke flow.
+
+## Create a DB2Role
+
+```yaml
+apiVersion: engine.kubevault.com/v1alpha1
+kind: DB2Role
+metadata:
+  name: app
+  namespace: demo
+spec:
+  secretEngineRef:
+    name: db2-engine
+  defaultTTL: 24h
+  maxTTL: 168h
+```
+
+```bash
+$ kubectl apply -f db2-role.yaml
+db2role.engine.kubevault.com/app created
+$ kubectl get db2role -n demo
+NAME   STATUS    AGE
+app    Success   8s
+```
+
+The KubeVault operator writes the role metadata as `database/roles/k8s.<cluster>.demo.app`. Db2's dynamic creds endpoint will still return the documented "dynamic credentials are not supported" error — that's the plugin contract; pair the `DB2Role` with `bao write database/static-roles/<name>` and a pre-existing Db2 principal.
+
+## Rotate static credentials
+
+Configure the static-roles binding directly against OpenBao (the static-role API is not currently exposed via a KubeVault CRD):
+
+```bash
+$ bao write database/static-roles/k8s.<cluster>.demo.app \
+    db_name=k8s.<cluster>.demo.db2 \
+    username=APP \
+    rotation_period=24h
+```
+
+`bao read database/static-creds/k8s.<cluster>.demo.app` returns the latest rotated password. KubeVault revokes the role on `DB2Role` deletion via the standard finalizer path.
+
+## Cleanup
+
+```bash
+$ kubectl delete db2role -n demo app
+$ kubectl delete secretengine -n demo db2-engine
+```
+
+## Caveats
+
+- **No dynamic credentials.** `bao read database/creds/<role>` always returns "dynamic credentials are not supported".
+- **Out-of-band principal management.** Provision Db2 principals via your configuration management; the plugin rotates passwords via `bao` audit but cannot apply them to the Db2 auth source.
+- **Insecure flag.** `spec.db2.insecure=true` disables TLS verification against the Db2 REST endpoint. Use only in dev.

--- a/docs/guides/secret-engines/db2/overview.md
+++ b/docs/guides/secret-engines/db2/overview.md
@@ -14,7 +14,7 @@ section_menu_id: guides
 
 # Manage IBM Db2 credentials using the KubeVault operator
 
-OpenBao's [`db2-database-plugin`](https://github.com/sigilr/openbao/pull/19) is a **static-credentials-only** database plugin. There is no pure-Go Db2 driver and most production deployments delegate user management to the OS or LDAP, so the plugin does not support dynamic `bao read database/creds/<role>` calls. Instead, KubeVault treats Db2 like a static-credentials engine: you provision the Db2 principal out of band, then use [`DB2Role`](/docs/concepts/secret-engine-crds/database-secret-engine/db2role.md) to attach rotation metadata to that pre-existing principal.
+OpenBao's [`db2-database-plugin`](https://github.com/sigilr/openbao/pull/19) is a **static-credentials-only** database plugin. There is no pure-Go Db2 driver and most production deployments delegate user management to the OS or LDAP, so the plugin does not support dynamic `bao read database/creds/<role>` calls. Instead, KubeVault treats Db2 like a static-credentials engine: you provision the Db2 principal out of band, then use [`DB2Role`](/docs/concepts/secret-engine-crds/database-secret-engine/db2.md) to attach rotation metadata to that pre-existing principal.
 
 The same CRD shape is used both for the in-process `db2-database-plugin` and for the hub-spoke `remote-db2-plugin`; the difference is whether the [Vault AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md) referenced by `SecretEngine.spec.vaultRef` is marked `deploymentMode: RemoteAgent` (then the SecretEngine controller rewrites `plugin_name` to `remote-db2-plugin` and attaches `spoke_name`).
 
@@ -22,7 +22,7 @@ You need to be familiar with the following CRDs:
 
 - [AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md)
 - [SecretEngine](/docs/concepts/secret-engine-crds/secretengine.md)
-- [DB2Role](/docs/concepts/secret-engine-crds/database-secret-engine/db2role.md)
+- [DB2Role](/docs/concepts/secret-engine-crds/database-secret-engine/db2.md)
 
 ## Before you begin
 

--- a/docs/guides/secret-engines/db2/overview.md
+++ b/docs/guides/secret-engines/db2/overview.md
@@ -57,6 +57,7 @@ spec:
   clientConfig:
     url: http://db2-dbapi.demo.svc:50000
   secret:
+    kind: Secret
     name: db2-cred
 ---
 apiVersion: v1


### PR DESCRIPTION
User-facing guide for the OpenBao [`db2-database-plugin`](https://github.com/sigilr/openbao/pull/19) secret engine: AppBinding → SecretEngine → DB2Role → SecretAccessRequest flow, plugin-specific caveats, and example payloads.

Companion PRs:
- apimachinery (CRDs): kubevault/apimachinery
- operator (reconciler): kubevault/operator

## Test plan
- [ ] Render docs locally and click through the new page