### PR TITLE
docs/guides: add DocumentDB secret engine guide

### DIFF
--- a/docs/concepts/secret-engine-crds/database-secret-engine/documentdb.md
+++ b/docs/concepts/secret-engine-crds/database-secret-engine/documentdb.md
@@ -1,0 +1,121 @@
+---
+title: DocumentDBRole | Vault Secret Engine
+menu:
+  docs_{{ .version }}:
+    identifier: documentdbrole-database-crds
+    name: DocumentDBRole
+    parent: database-crds-concepts
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: concepts
+---
+
+> New to KubeVault? Please start [here](/docs/concepts/README.md).
+
+# DocumentDBRole
+
+## What is DocumentDBRole
+
+A `DocumentDBRole` is a Kubernetes `CustomResourceDefinition` (CRD) which allows a user to create a database secret engine role in a Kubernetes native way.
+
+When a `DocumentDBRole` is created, the KubeVault operator creates a [role](https://www.vaultproject.io/api/secret/databases/index.html#create-role) according to specification.
+If the user deletes the `DocumentDBRole` CRD, then the respective role will also be deleted from Vault.
+
+## DocumentDBRole CRD Specification
+
+Like any official Kubernetes resource, a `DocumentDBRole` object has `TypeMeta`, `ObjectMeta`, `Spec` and `Status` sections.
+
+A sample `DocumentDBRole` object is shown below:
+
+```yaml
+apiVersion: engine.kubevault.com/v1alpha1
+kind: DocumentDBRole
+metadata:
+  name: documentdb-role
+  namespace: demo
+spec:
+  secretEngineRef:
+    name: vault-app
+  creationStatements:
+    - '{ "db": "admin", "roles": [{ "role": "readWrite" }] }'
+status:
+  observedGeneration: 1
+  phase: Success
+```
+
+> Note: To resolve the naming conflict, name of the role in Vault will follow this format: `k8s.{clusterName}.{metadata.namespace}.{metadata.name}`
+
+Here, we are going to describe the various sections of the `DocumentDBRole` crd.
+
+### DocumentDBRole Spec
+
+DocumentDBRole `spec` contains information that necessary for creating a database role.
+
+```yaml
+spec:
+  secretEngineRef:
+    name: <vault-appbinding-name>
+  defaultTTL: <default-ttl>
+  maxTTL: <max-ttl>
+  creationStatements:
+    - "statement-0"
+  revocationStatements:
+    - "statement-0"
+```
+
+DocumentDBRole spec has the following fields:
+
+#### spec.secretEngineRef
+
+`spec.secretEngineRef` is a `required` field that specifies the name of a `SecretEngine`.
+
+```yaml
+spec:
+  secretEngineRef:
+    name: documentdb-secret-engine
+```
+
+#### spec.creationStatements
+
+`spec.creationStatements` is a `required` field that specifies a JSON role document used to provision the user. The exact schema depends on the plugin — see the example below. DocumentDB reuses the MongoDB driver, so each entry is a JSON role document.
+
+```yaml
+spec:
+  creationStatements:
+    - '{ "db": "admin", "roles": [{ "role": "readWrite" }] }'
+```
+
+#### spec.defaultTTL
+
+`spec.defaultTTL` is an `optional` field that specifies the TTL for the leases associated with this role.
+Accepts time suffixed strings ("1h") or an integer number of seconds. Defaults to system/engine default TTL time.
+
+```yaml
+spec:
+  defaultTTL: "1h"
+```
+
+#### spec.maxTTL
+
+`spec.maxTTL` is an `optional` field that specifies the maximum TTL for the leases associated with this role.
+Accepts time suffixed strings ("1h") or an integer number of seconds. Defaults to system/engine default TTL time.
+
+```yaml
+spec:
+  maxTTL: "1h"
+```
+
+#### spec.revocationStatements
+
+`spec.revocationStatements` is an `optional` field that specifies a list of database statements to be executed to revoke a user. If not provided defaults to a generic drop user statement.
+
+### DocumentDBRole Status
+
+`status` shows the status of the DocumentDBRole. It is managed by the KubeVault operator. It contains the following fields:
+
+- `observedGeneration`: Specifies the most recent generation observed for this resource. It corresponds to the resource's generation,
+    which is updated on mutation by the API Server.
+
+- `phase`: Indicates whether the role successfully applied to Vault or not.
+
+- `conditions` : Represent observations of a DocumentDBRole.

--- a/docs/concepts/secret-engine-crds/database-secret-engine/documentdb.md
+++ b/docs/concepts/secret-engine-crds/database-secret-engine/documentdb.md
@@ -119,3 +119,13 @@ spec:
 - `phase`: Indicates whether the role successfully applied to Vault or not.
 
 - `conditions` : Represent observations of a DocumentDBRole.
+
+## Namespace inheritance (tenant isolation)
+
+A `DocumentDBRole` never sets or resolves an OpenBao namespace itself. It always inherits the
+**effective namespace** of the `SecretEngine` it references via `spec.secretEngineRef`
+(`SecretEngine.status.effectiveNamespace`) — empty for root, or the tenant's OpenBao
+namespace once [tenant isolation](/docs/guides/tenant-isolation/overview.md) has placed
+that engine in one. Every credential this role issues, and every revocation
+(`SecretAccessRequest`), is scoped to that same namespace automatically — no
+`DocumentDBRole`-level configuration is needed.

--- a/docs/guides/hub-spoke/deploy-hub-spoke.md
+++ b/docs/guides/hub-spoke/deploy-hub-spoke.md
@@ -239,7 +239,7 @@ spec:
 
 Because the AppBinding's `deploymentMode` is `RemoteRelay`, the SecretEngine controller configures the hub mount with `plugin_name: remote-postgres-plugin` and `spoke_name: cluster-1`. The hub proxies every credential operation to the spoke relay, which runs the real `postgresql-database-plugin` in-process against the spoke-local database.
 
-Postgres, MySQL, MariaDB, Redis, and Valkey are supported through the spoke relay. MongoDB and Elasticsearch are not; a SecretEngine for those against a `RemoteRelay` AppBinding is rejected on apply by the validating webhook.
+Postgres, MySQL, MariaDB, Redis, Valkey, and DocumentDB are supported through the spoke relay. MongoDB and Elasticsearch are not; a SecretEngine for those against a `RemoteRelay` AppBinding is rejected on apply by the validating webhook.
 
 Request credentials the usual way with a `SecretAccessRequest`; see the [secret engine guides](/docs/guides/secret-engines/postgres/overview.md).
 

--- a/docs/guides/secret-engines/documentdb/_index.md
+++ b/docs/guides/secret-engines/documentdb/_index.md
@@ -1,0 +1,10 @@
+---
+title: DocumentDB | Vault Secret Engine
+menu:
+  docs_{{ .version }}:
+    identifier: documentdb-secret-engines
+    name: DocumentDB
+    parent: secret-engines-guides
+    weight: 160
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/secret-engines/documentdb/csi-driver.md
+++ b/docs/guides/secret-engines/documentdb/csi-driver.md
@@ -1,0 +1,291 @@
+---
+title: Mount DocumentDB Secrets using CSI Driver
+menu:
+  docs_{{ .version }}:
+    identifier: csi-driver-documentdb
+    name: CSI Driver
+    parent: documentdb-secret-engines
+    weight: 15
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+# Mount DocumentDB Secrets using CSI Driver
+
+## Kubernetes Secrets Store CSI Driver
+
+Secrets Store CSI driver for Kubernetes secrets - Integrates secrets stores with Kubernetes via a [Container Storage Interface (CSI)](https://kubernetes-csi.github.io/docs/) volume.
+
+The Secrets Store CSI driver `secrets-store.csi.k8s.io` allows Kubernetes to mount multiple secrets, keys, and certs stored in enterprise-grade external secrets stores into their pods as a volume. Once the Volume is attached, the data in it is mounted into the container’s file system.
+
+![Secrets-store CSI architecture](/docs/guides/secret-engines/csi_architecture.svg)
+
+When the `Pod` is created through the K8s API, it’s scheduled on to a node. The `kubelet` process on the node looks at the pod spec & see if there's any `volumeMount` request. The `kubelet` issues an `RPC` to the `CSI driver` to mount the volume. The `CSI driver` creates & mounts `tmpfs` into the pod. Then the `CSI driver` issues a request to the `Provider`. The provider talks to the external secrets store to fetch the secrets & write them to the pod volume as files. At this point, volume is successfully mounted & the pod starts running.
+
+You can read more about the Kubernetes Secrets Store CSI Driver [here](https://secrets-store-csi-driver.sigs.k8s.io/).
+
+## Consuming Secrets
+
+At first, you need to have a Kubernetes 1.16 or later cluster, and the kubectl command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/). To check the version of your cluster, run:
+
+```bash
+$ kubectl version --short
+Client Version: v1.21.2
+Server Version: v1.21.1
+```
+
+Before you begin:
+
+- Install KubeVault operator in your cluster from [here](/docs/setup/README.md).
+- Install Secrets Store CSI driver for Kubernetes secrets in your cluster from [here](https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation.html).
+- Install Vault Specific CSI provider from [here](https://github.com/hashicorp/vault-csi-provider)
+
+To keep things isolated, we are going to use a separate namespace called `demo` throughout this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> Note: YAML files used in this tutorial stored in [examples](/docs/examples/guides/secret-engines/documentdb) folder in GitHub repository [KubeVault/docs](https://github.com/kubevault/kubevault)
+
+## Vault Server
+
+If you don't have a Vault Server, you can deploy it by using the KubeVault operator.
+
+- [Deploy Vault Server](/docs/guides/vault-server/vault-server.md)
+
+The KubeVault operator can manage policies and secret engines of Vault servers which are not provisioned by the KubeVault operator. You need to configure both the Vault server and the cluster so that the KubeVault operator can communicate with your Vault server.
+
+- [Configure cluster and Vault server](/docs/guides/vault-server/external-vault-sever.md#configuration)
+
+Now, we have the [AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md) that contains connection and authentication information about the Vault server. And we also have the service account that the Vault server can authenticate.
+
+```bash
+$ kubectl get appbinding -n demo
+NAME    AGE
+vault   50m
+
+$ kubectl get appbinding -n demo vault -o yaml
+apiVersion: appcatalog.appscode.com/v1alpha1
+kind: AppBinding
+metadata:
+  creationTimestamp: "2021-08-16T08:23:38Z"
+  generation: 1
+  labels:
+    app.kubernetes.io/instance: vault
+    app.kubernetes.io/managed-by: kubevault.com
+    app.kubernetes.io/name: vaultservers.kubevault.com
+  name: vault
+  namespace: demo
+  ownerReferences:
+  - apiVersion: kubevault.com/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: VaultServer
+    name: vault
+    uid: 6b405147-93da-41ff-aad3-29ae9f415d0a
+  resourceVersion: "602898"
+  uid: b54873fd-0f34-42f7-bdf3-4e667edb4659
+spec:
+  clientConfig:
+    service:
+      name: vault
+      port: 8200
+      scheme: http
+  parameters:
+    apiVersion: config.kubevault.com/v1alpha1
+    kind: VaultServerConfiguration
+    kubernetes:
+      serviceAccountName: vault
+      tokenReviewerServiceAccountName: vault-k8s-token-reviewer
+      usePodServiceAccountForCSIDriver: true
+    path: kubernetes
+    vaultRole: vault-policy-controller
+```
+
+## Enable & Configure DocumentDB SecretEngine
+
+### Enable DocumentDB SecretEngine
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/documentdb/secretengine.yaml
+secretengine.engine.kubevault.com/documentdb-engine created
+```
+
+### Create DocumentDBRole
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/documentdb/secretenginerole.yaml
+documentdbrole.engine.kubevault.com/documentdb-superuser-role created
+```
+
+Let's say pod's service account name is `test-user-account` located in `demo` namespace. We need to create a [VaultPolicy](/docs/concepts/policy-crds/vaultpolicy.md) and a [VaultPolicyBinding](/docs/concepts/policy-crds/vaultpolicybinding.md) so that the pod has access to read secrets from the Vault server.
+
+### Create Service Account for Pod
+
+Let's create the service account `test-user-account` which will be used in VaultPolicyBinding.
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-user-account
+  namespace: demo
+```
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/documentdb/serviceaccount.yaml
+serviceaccount/test-user-account created
+
+$ kubectl get serviceaccount -n demo
+NAME                SECRETS   AGE
+test-user-account   1         4h10m
+```
+
+### Create SecretRoleBinding for Pod's Service Account
+
+SecretRoleBinding will create VaultPolicy and VaultPolicyBinding inside vault.
+When a VaultPolicyBinding object is created, the KubeVault operator create an auth role in the Vault server. The role name is generated by the following naming format: `k8s.(clusterName or -).namespace.name`. Here, it is `k8s.kubevault.com.demo.documentdb-superuser-role`.
+
+```yaml
+apiVersion: engine.kubevault.com/v1alpha1
+kind: SecretRoleBinding
+metadata:
+  name: secret-role-binding
+  namespace: demo
+spec:
+  roles:
+    - kind: DocumentDBRole
+      name: documentdb-superuser-role
+  subjects:
+    - kind: ServiceAccount
+      name: test-user-account
+      namespace: demo
+```
+
+Let's create SecretRoleBinding:
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/documentdb/secretrolebinding.yaml
+secretrolebinding.engine.kubevault.com/secret-role-binding created
+```
+Check if the VaultPolicy and the VaultPolicyBinding are successfully registered to the Vault server:
+
+```bash
+$ kubectl get vaultpolicy -n demo
+NAME                                         STATUS    AGE
+srb-demo-secret-role-binding                 Success   8s
+
+$ kubectl get vaultpolicybinding -n demo
+NAME                                            STATUS    AGE
+srb-demo-secret-role-binding                    Success   10s
+```
+
+## Mount secrets into a Kubernetes pod
+
+So, we can create `SecretProviderClass` now. You can read more about `SecretProviderClass` [here](https://secrets-store-csi-driver.sigs.k8s.io/concepts.html#secretproviderclass).
+
+### Create SecretProviderClass
+
+Create `SecretProviderClass` object with the following content:
+
+```yaml
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: vault-db-provider
+  namespace: demo
+spec:
+  provider: vault
+  parameters:
+    vaultAddress: "http://vault.demo:8200"
+    roleName: "k8s.-.demo.documentdb-reader-role"
+    objects: |
+      - objectName: "documentdb-creds-username"
+        secretPath: "your-database-path/creds/k8s.-.demo.documentdb-superuser-role"
+        secretKey: "username"
+      - objectName: "documentdb-creds-password"
+        secretPath: "your-database-path/creds/k8s.-.demo.documentdb-superuser-role"
+        secretKey: "password"
+
+```
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/documentdb/secretproviderclass.yaml
+secretproviderclass.secrets-store.csi.x-k8s.io/vault-db-provider created
+```
+NOTE: The `SecretProviderClass` needs to be created in the same namespace as the pod.
+
+### Create Pod
+
+Now we can create a `Pod` to consume the `DocumentDB` secrets. When the `Pod` is created, the `Provider` fetches the secret and writes them to Pod's volume as files. At this point, the volume is successfully mounted and the `Pod` starts running.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-app
+  namespace: demo
+spec:
+  serviceAccountName: test-user-account
+  containers:
+    - image: jweissig/app:0.0.1
+      name: demo-app
+      imagePullPolicy: Always
+      volumeMounts:
+        - name: secrets-store-inline
+          mountPath: "/secrets-store/documentdb-creds"
+          readOnly: true
+  volumes:
+    - name: secrets-store-inline
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: "vault-db-provider"
+
+```
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/documentdb/pod.yaml
+pod/demo-app created
+```
+## Test & Verify
+
+Check if the Pod is running successfully, by running:
+
+```bash
+$ kubectl get pods -n demo
+NAME                       READY   STATUS    RESTARTS   AGE
+demo-app                   1/1     Running   0          11s
+```
+
+### Verify Secret
+
+If the Pod is running successfully, then check inside the app container by running
+
+```bash
+$ kubectl exec -it -n demo pod/demo-app -- /bin/sh
+/ # ls /secrets-store/documentdb-creds
+documentdb-creds-password  documentdb-creds-username
+
+/ # cat /secrets-store/documentdb-creds/documentdb-creds-password
+TAu2Zvg1WYE07W8Uf-nW
+
+/ # cat /secrets-store/documentdb-creds/documentdb-creds-username
+v-kubernetes-test-k8s.-.demo.documentdb-s-iPkxiH80Ollq2QgF82Ab-1629178048
+
+/ # exit
+```
+
+So, we can see that the secret `db-username` and `db-password` is mounted into the pod, where the secret key is mounted as file and value is the content of that file.
+
+## Cleaning up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+$ kubectl delete ns demo
+namespace "demo" deleted
+
+```

--- a/docs/guides/secret-engines/documentdb/overview.md
+++ b/docs/guides/secret-engines/documentdb/overview.md
@@ -1,0 +1,211 @@
+---
+title: Manage DocumentDB credentials using the KubeVault operator
+menu:
+  docs_{{ .version }}:
+    identifier: overview-documentdb
+    name: Overview
+    parent: documentdb-secret-engines
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeVault? Please start [here](/docs/concepts/README.md).
+
+# Manage DocumentDB credentials using the KubeVault operator
+
+OpenBao's [`documentdb-database-plugin`](https://github.com/sigilr/openbao/pull/9) is a **dynamic-credentials** database plugin for [DocumentDB](https://github.com/documentdb/documentdb), the open-source PostgreSQL extension + gateway that speaks the MongoDB wire protocol (the same engine powers Azure Cosmos DB for MongoDB vCore). The plugin reuses the official `mongo-driver`, so KubeVault treats DocumentDB like the MongoDB engine: the `DocumentDBRole.spec.creationStatements` field is a JSON role document, and credentials are issued dynamically through a `SecretAccessRequest`.
+
+The same CRD shape is used both for the in-process `documentdb-database-plugin` and for the hub-spoke `remote-documentdb-plugin`; the difference is whether the [Vault AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md) referenced by `SecretEngine.spec.vaultRef` is marked `deploymentMode: RemoteAgent` (then the SecretEngine controller rewrites `plugin_name` to `remote-documentdb-plugin` and attaches `spoke_name`).
+
+You need to be familiar with the following CRDs:
+
+- [AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md)
+- [SecretEngine](/docs/concepts/secret-engine-crds/secretengine.md)
+- [DocumentDBRole](/docs/concepts/secret-engine-crds/database-secret-engine/documentdbrole.md)
+
+## Before you begin
+
+- Install KubeVault operator in your cluster from [here](/docs/setup/README.md).
+- Run a DocumentDB gateway. The upstream docker quickstart at https://github.com/documentdb/documentdb publishes the gateway on `:10260` with a self-signed certificate; production deployments should terminate with a real CA-issued cert.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+## Vault Server
+
+Deploy a Vault Server using the KubeVault operator: [Deploy Vault Server](/docs/guides/vault-server/vault-server.md). The KubeVault operator will create an [AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md) wiring up Kubernetes auth.
+
+```bash
+$ kubectl get appbinding -n demo vault -o yaml
+```
+
+## AppBinding for DocumentDB
+
+Create an `AppBinding` pointing at the DocumentDB gateway. The URL is a standard MongoDB connection URI; the referenced Secret carries the username and password the plugin uses to log in as the rotation principal.
+
+```yaml
+apiVersion: appcatalog.appscode.com/v1alpha1
+kind: AppBinding
+metadata:
+  name: documentdb
+  namespace: demo
+spec:
+  clientConfig:
+    url: mongodb://docdb.demo.svc:10260/?tls=true&tlsInsecure=true
+  secret:
+    name: documentdb-cred
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: documentdb-cred
+  namespace: demo
+type: kubernetes.io/basic-auth
+stringData:
+  username: vault-root
+  password: change-me
+```
+
+> The `tlsInsecure=true` query parameter pairs with `SecretEngine.spec.documentdb.insecure: true` below — both are intended for the docker quickstart with its self-signed cert. Drop both knobs once you front the gateway with a real CA.
+
+## Enable and Configure DocumentDB Secret Engine
+
+When a [SecretEngine](/docs/concepts/secret-engine-crds/secretengine.md) crd object is created, the KubeVault operator will enable a secret engine on a specified path and configure the secret engine with the given configuration.
+
+A sample `SecretEngine` for DocumentDB:
+
+```yaml
+apiVersion: engine.kubevault.com/v1alpha1
+kind: SecretEngine
+metadata:
+  name: documentdb-engine
+  namespace: demo
+spec:
+  vaultRef:
+    name: vault
+  documentdb:
+    databaseRef:
+      name: documentdb
+      namespace: demo
+    pluginName: documentdb-database-plugin   # optional; this is the default
+    allowedRoles:
+      - "*"
+    writeConcern: '{ "wtimeout": 5000 }'      # optional, mongo-style
+    insecure: true                            # docker quickstart with self-signed cert
+```
+
+Apply it and wait for `STATUS=Success`:
+
+```bash
+$ kubectl apply -f documentdb-engine.yaml
+secretengine.engine.kubevault.com/documentdb-engine created
+
+$ kubectl get secretengines -n demo
+NAME                STATUS    AGE
+documentdb-engine   Success   10s
+```
+
+Use `kubectl describe secretengine -n demo documentdb-engine` to inspect error events, if any.
+
+## Create a DocumentDBRole
+
+A [`DocumentDBRole`](/docs/concepts/secret-engine-crds/database-secret-engine/documentdbrole.md) describes how the plugin should mint a dynamic credential. Because DocumentDB speaks the MongoDB wire protocol, `creationStatements` is a JSON role document — the same format the MongoDB engine accepts.
+
+```yaml
+apiVersion: engine.kubevault.com/v1alpha1
+kind: DocumentDBRole
+metadata:
+  name: documentdb-readwrite
+  namespace: demo
+spec:
+  secretEngineRef:
+    name: documentdb-engine
+  creationStatements:
+    - '{ "db": "admin", "roles": [{ "role": "readWrite" }] }'
+  defaultTTL: 1h
+  maxTTL: 24h
+```
+
+Apply and verify:
+
+```bash
+$ kubectl apply -f documentdb-role.yaml
+documentdbrole.engine.kubevault.com/documentdb-readwrite created
+
+$ kubectl get documentdbrole -n demo
+NAME                   STATUS    AGE
+documentdb-readwrite   Success   12s
+```
+
+The role name in Vault follows the format `k8s.{clusterName}.{metadata.namespace}.{metadata.name}`, so you can verify directly with the Vault CLI:
+
+```bash
+$ vault read your-database-path/roles/k8s.-.demo.documentdb-readwrite
+Key                      Value
+---                      -----
+creation_statements      [{ "db": "admin", "roles": [{ "role": "readWrite" }] }]
+db_name                  k8s.-.demo.documentdb
+default_ttl              1h
+max_ttl                  24h
+```
+
+Deleting the `DocumentDBRole` removes the role from Vault.
+
+## Issue DocumentDB credentials
+
+Request a dynamic credential by creating a `SecretAccessRequest`:
+
+```yaml
+apiVersion: engine.kubevault.com/v1alpha1
+kind: SecretAccessRequest
+metadata:
+  name: documentdb-cred-rqst
+  namespace: demo
+spec:
+  roleRef:
+    kind: DocumentDBRole
+    name: documentdb-readwrite
+  subjects:
+    - kind: ServiceAccount
+      name: demo-sa
+      namespace: demo
+```
+
+Approve it through the KubeVault CLI:
+
+```bash
+$ kubectl vault approve secretaccessrequest documentdb-cred-rqst -n demo
+approved
+```
+
+Once approved, the operator issues the credential, stores it in a `Secret`, and binds the listed subjects via a `Role`/`RoleBinding`. The credential lives on the lease until you delete the `SecretAccessRequest` or it expires.
+
+```bash
+$ kubectl get secretaccessrequest documentdb-cred-rqst -n demo -o json | jq '.status'
+{
+  "lease": {
+    "duration": "1h0m0s",
+    "id": "your-database-path/creds/k8s.-.demo.documentdb-readwrite/abc...",
+    "renewable": true
+  },
+  "secret": {
+    "name": "documentdb-cred-rqst-xxxxxx"
+  }
+}
+
+$ kubectl get secret -n demo documentdb-cred-rqst-xxxxxx -o jsonpath='{.data.username}' | base64 -d
+v-kubernetes-demo-XXXXXXXX
+
+$ kubectl get secret -n demo documentdb-cred-rqst-xxxxxx -o jsonpath='{.data.password}' | base64 -d
+xxxxxxxxxxxxxxxxxx
+```
+
+Use the issued `username` / `password` to log in to the DocumentDB gateway over the mongo wire protocol; the credential is revoked when the `SecretAccessRequest` is deleted.
+
+## Further reading
+
+- DocumentDB engine: https://github.com/documentdb/documentdb
+- OpenBao DocumentDB plugin: https://github.com/sigilr/openbao/pull/9


### PR DESCRIPTION
User-facing guide for the OpenBao [`documentdb-database-plugin`](https://github.com/sigilr/openbao/pull/9) secret engine: AppBinding → SecretEngine → DocumentDBRole → SecretAccessRequest flow, plugin-specific caveats, and example payloads.

Companion PRs:
- apimachinery (CRDs): kubevault/apimachinery
- operator (reconciler): kubevault/operator

## Test plan
- [ ] Render docs locally and click through the new page