### PR TITLE
docs/guides: add Microsoft SQL Server secret engine guide

### DIFF
--- a/docs/concepts/secret-engine-crds/database-secret-engine/mssqlserver.md
+++ b/docs/concepts/secret-engine-crds/database-secret-engine/mssqlserver.md
@@ -130,3 +130,13 @@ rollback a create operation in the event of an error. Not every plugin type will
 - `phase`: Indicates whether the role successfully applied to Vault or not.
 
 - `conditions` : Represent observations of a MSSQLServerRole.
+
+## Namespace inheritance (tenant isolation)
+
+A `MSSQLServerRole` never sets or resolves an OpenBao namespace itself. It always inherits the
+**effective namespace** of the `SecretEngine` it references via `spec.secretEngineRef`
+(`SecretEngine.status.effectiveNamespace`) — empty for root, or the tenant's OpenBao
+namespace once [tenant isolation](/docs/guides/tenant-isolation/overview.md) has placed
+that engine in one. Every credential this role issues, and every revocation
+(`SecretAccessRequest`), is scoped to that same namespace automatically — no
+`MSSQLServerRole`-level configuration is needed.

--- a/docs/concepts/secret-engine-crds/database-secret-engine/mssqlserver.md
+++ b/docs/concepts/secret-engine-crds/database-secret-engine/mssqlserver.md
@@ -1,0 +1,132 @@
+---
+title: MSSQLServerRole | Vault Secret Engine
+menu:
+  docs_{{ .version }}:
+    identifier: mssqlserverrole-database-crds
+    name: MSSQLServerRole
+    parent: database-crds-concepts
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: concepts
+---
+
+> New to KubeVault? Please start [here](/docs/concepts/README.md).
+
+# MSSQLServerRole
+
+## What is MSSQLServerRole
+
+A `MSSQLServerRole` is a Kubernetes `CustomResourceDefinition` (CRD) which allows a user to create a database secret engine role in a Kubernetes native way.
+
+When a `MSSQLServerRole` is created, the KubeVault operator creates a [role](https://www.vaultproject.io/api/secret/databases/index.html#create-role) according to specification.
+If the user deletes the `MSSQLServerRole` CRD, then the respective role will also be deleted from Vault.
+
+## MSSQLServerRole CRD Specification
+
+Like any official Kubernetes resource, a `MSSQLServerRole` object has `TypeMeta`, `ObjectMeta`, `Spec` and `Status` sections.
+
+A sample `MSSQLServerRole` object is shown below:
+
+```yaml
+apiVersion: engine.kubevault.com/v1alpha1
+kind: MSSQLServerRole
+metadata:
+  name: mssql-role
+  namespace: demo
+spec:
+  secretEngineRef:
+    name: vault-app
+  creationStatements:
+    - "CREATE LOGIN [{{name}}] WITH PASSWORD = '{{password}}';"
+    - "CREATE USER [{{name}}] FOR LOGIN [{{name}}];"
+status:
+  observedGeneration: 1
+  phase: Success
+```
+
+> Note: To resolve the naming conflict, name of the role in Vault will follow this format: `k8s.{clusterName}.{metadata.namespace}.{metadata.name}`
+
+Here, we are going to describe the various sections of the `MSSQLServerRole` crd.
+
+### MSSQLServerRole Spec
+
+MSSQLServerRole `spec` contains information that necessary for creating a database role.
+
+```yaml
+spec:
+  secretEngineRef:
+    name: <vault-appbinding-name>
+  defaultTTL: <default-ttl>
+  maxTTL: <max-ttl>
+  creationStatements:
+    - "statement-0"
+    - "statement-1"
+  revocationStatements:
+    - "statement-0"
+  rollbackStatements:
+    - "statement-0"
+```
+
+MSSQLServerRole spec has the following fields:
+
+#### spec.secretEngineRef
+
+`spec.secretEngineRef` is a `required` field that specifies the name of a `SecretEngine`.
+
+```yaml
+spec:
+  secretEngineRef:
+    name: mssql-secret-engine
+```
+
+#### spec.creationStatements
+
+`spec.creationStatements` is a `required` field that specifies a list of database statements executed to create and configure a user.
+The `{{name}}` and `{{password}}` values will be substituted by Vault.
+
+```yaml
+spec:
+  creationStatements:
+    - "CREATE LOGIN [{{name}}] WITH PASSWORD = '{{password}}';"
+    - "CREATE USER [{{name}}] FOR LOGIN [{{name}}];"
+```
+
+#### spec.defaultTTL
+
+`spec.defaultTTL` is an `optional` field that specifies the TTL for the leases associated with this role.
+Accepts time suffixed strings ("1h") or an integer number of seconds. Defaults to system/engine default TTL time.
+
+```yaml
+spec:
+  defaultTTL: "1h"
+```
+
+#### spec.maxTTL
+
+`spec.maxTTL` is an `optional` field that specifies the maximum TTL for the leases associated with this role.
+Accepts time suffixed strings ("1h") or an integer number of seconds. Defaults to system/engine default TTL time.
+
+```yaml
+spec:
+  maxTTL: "1h"
+```
+
+#### spec.revocationStatements
+
+`spec.revocationStatements` is an `optional` field that specifies a list of database statements to be executed to revoke a user. The `{{name}}` value will be substituted. If not provided defaults to a generic drop user statement.
+
+#### spec.rollbackStatements
+
+`spec.rollbackStatements` is an `optional` field that specifies a list of database statements to be executed
+rollback a create operation in the event of an error. Not every plugin type will support this functionality.
+
+### MSSQLServerRole Status
+
+`status` shows the status of the MSSQLServerRole. It is managed by the KubeVault operator. It contains the following fields:
+
+- `observedGeneration`: Specifies the most recent generation observed for this resource. It corresponds to the resource's generation,
+    which is updated on mutation by the API Server.
+
+- `phase`: Indicates whether the role successfully applied to Vault or not.
+
+- `conditions` : Represent observations of a MSSQLServerRole.

--- a/docs/examples/guides/secret-engines/mssqlserver/pod.yaml
+++ b/docs/examples/guides/secret-engines/mssqlserver/pod.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-app
+  namespace: demo
+spec:
+  serviceAccountName: test-user-account
+  containers:
+    - image: jweissig/app:0.0.1
+      name: demo-app
+      imagePullPolicy: Always
+      volumeMounts:
+        - name: secrets-store-inline
+          mountPath: "/secrets-store/mssqlserver-creds"
+          readOnly: true
+  volumes:
+    - name: secrets-store-inline
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: "vault-db-provider"

--- a/docs/examples/guides/secret-engines/mssqlserver/secretengine.yaml
+++ b/docs/examples/guides/secret-engines/mssqlserver/secretengine.yaml
@@ -1,0 +1,18 @@
+apiVersion: engine.kubevault.com/v1alpha1
+kind: SecretEngine
+metadata:
+  name: mssqlserver-engine
+  namespace: demo
+spec:
+  vaultRef:
+    name: vault
+  mssqlserver:
+    databaseRef:
+      name: mssqlserver
+      namespace: demo
+    pluginName: mssql-database-plugin
+    allowedRoles:
+      - "*"
+    maxOpenConnections: 4
+    maxIdleConnections: 0
+    maxConnectionLifetime: 0s

--- a/docs/examples/guides/secret-engines/mssqlserver/secretenginerole.yaml
+++ b/docs/examples/guides/secret-engines/mssqlserver/secretenginerole.yaml
@@ -1,0 +1,15 @@
+apiVersion: engine.kubevault.com/v1alpha1
+kind: MSSQLServerRole
+metadata:
+  name: mssqlserver-superuser-role
+  namespace: demo
+spec:
+  secretEngineRef:
+    name: mssqlserver-engine
+  creationStatements:
+    - |
+      CREATE LOGIN [{{name}}] WITH PASSWORD = '{{password}}';
+      CREATE USER [{{name}}] FOR LOGIN [{{name}}];
+      GRANT SELECT ON SCHEMA::dbo TO [{{name}}];
+  defaultTTL: 1h
+  maxTTL: 24h

--- a/docs/examples/guides/secret-engines/mssqlserver/secretproviderclass.yaml
+++ b/docs/examples/guides/secret-engines/mssqlserver/secretproviderclass.yaml
@@ -1,0 +1,17 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: vault-db-provider
+  namespace: demo
+spec:
+  provider: vault
+  parameters:
+    vaultAddress: "http://vault.demo:8200"
+    roleName: "k8s.-.demo.mssqlserver-reader-role"
+    objects: |
+      - objectName: "mssqlserver-creds-username"
+        secretPath: "your-database-path/creds/k8s.-.demo.mssqlserver-superuser-role"
+        secretKey: "username"
+      - objectName: "mssqlserver-creds-password"
+        secretPath: "your-database-path/creds/k8s.-.demo.mssqlserver-superuser-role"
+        secretKey: "password"

--- a/docs/examples/guides/secret-engines/mssqlserver/secretrolebinding.yaml
+++ b/docs/examples/guides/secret-engines/mssqlserver/secretrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: engine.kubevault.com/v1alpha1
+kind: SecretRoleBinding
+metadata:
+  name: secret-role-binding
+  namespace: demo
+spec:
+  roles:
+    - kind: MSSQLServerRole
+      name: mssqlserver-superuser-role
+  subjects:
+    - kind: ServiceAccount
+      name: test-user-account
+      namespace: demo

--- a/docs/examples/guides/secret-engines/mssqlserver/serviceaccount.yaml
+++ b/docs/examples/guides/secret-engines/mssqlserver/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-user-account
+  namespace: demo

--- a/docs/guides/hub-spoke/deploy-hub-spoke.md
+++ b/docs/guides/hub-spoke/deploy-hub-spoke.md
@@ -239,7 +239,7 @@ spec:
 
 Because the AppBinding's `deploymentMode` is `RemoteRelay`, the SecretEngine controller configures the hub mount with `plugin_name: remote-postgres-plugin` and `spoke_name: cluster-1`. The hub proxies every credential operation to the spoke relay, which runs the real `postgresql-database-plugin` in-process against the spoke-local database.
 
-Postgres, MySQL, MariaDB, Redis, and Valkey are supported through the spoke relay. MongoDB and Elasticsearch are not; a SecretEngine for those against a `RemoteRelay` AppBinding is rejected on apply by the validating webhook.
+Postgres, MySQL, MariaDB, Redis, Valkey, and SQL Server are supported through the spoke relay. MongoDB and Elasticsearch are not; a SecretEngine for those against a `RemoteRelay` AppBinding is rejected on apply by the validating webhook.
 
 Request credentials the usual way with a `SecretAccessRequest`; see the [secret engine guides](/docs/guides/secret-engines/postgres/overview.md).
 

--- a/docs/guides/secret-engines/mssqlserver/_index.md
+++ b/docs/guides/secret-engines/mssqlserver/_index.md
@@ -1,0 +1,10 @@
+---
+title: Microsoft SQL Server | Vault Secret Engine
+menu:
+  docs_{{ .version }}:
+    identifier: mssqlserver-secret-engines
+    name: Microsoft SQL Server
+    parent: secret-engines-guides
+    weight: 240
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/secret-engines/mssqlserver/csi-driver.md
+++ b/docs/guides/secret-engines/mssqlserver/csi-driver.md
@@ -1,0 +1,291 @@
+---
+title: Mount Microsoft SQL Server Secrets using CSI Driver
+menu:
+  docs_{{ .version }}:
+    identifier: csi-driver-mssqlserver
+    name: CSI Driver
+    parent: mssqlserver-secret-engines
+    weight: 15
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+# Mount Microsoft SQL Server Secrets using CSI Driver
+
+## Kubernetes Secrets Store CSI Driver
+
+Secrets Store CSI driver for Kubernetes secrets - Integrates secrets stores with Kubernetes via a [Container Storage Interface (CSI)](https://kubernetes-csi.github.io/docs/) volume.
+
+The Secrets Store CSI driver `secrets-store.csi.k8s.io` allows Kubernetes to mount multiple secrets, keys, and certs stored in enterprise-grade external secrets stores into their pods as a volume. Once the Volume is attached, the data in it is mounted into the container’s file system.
+
+![Secrets-store CSI architecture](/docs/guides/secret-engines/csi_architecture.svg)
+
+When the `Pod` is created through the K8s API, it’s scheduled on to a node. The `kubelet` process on the node looks at the pod spec & see if there's any `volumeMount` request. The `kubelet` issues an `RPC` to the `CSI driver` to mount the volume. The `CSI driver` creates & mounts `tmpfs` into the pod. Then the `CSI driver` issues a request to the `Provider`. The provider talks to the external secrets store to fetch the secrets & write them to the pod volume as files. At this point, volume is successfully mounted & the pod starts running.
+
+You can read more about the Kubernetes Secrets Store CSI Driver [here](https://secrets-store-csi-driver.sigs.k8s.io/).
+
+## Consuming Secrets
+
+At first, you need to have a Kubernetes 1.16 or later cluster, and the kubectl command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/). To check the version of your cluster, run:
+
+```bash
+$ kubectl version --short
+Client Version: v1.21.2
+Server Version: v1.21.1
+```
+
+Before you begin:
+
+- Install KubeVault operator in your cluster from [here](/docs/setup/README.md).
+- Install Secrets Store CSI driver for Kubernetes secrets in your cluster from [here](https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation.html).
+- Install Vault Specific CSI provider from [here](https://github.com/hashicorp/vault-csi-provider)
+
+To keep things isolated, we are going to use a separate namespace called `demo` throughout this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> Note: YAML files used in this tutorial stored in [examples](/docs/examples/guides/secret-engines/mssqlserver) folder in GitHub repository [KubeVault/docs](https://github.com/kubevault/kubevault)
+
+## Vault Server
+
+If you don't have a Vault Server, you can deploy it by using the KubeVault operator.
+
+- [Deploy Vault Server](/docs/guides/vault-server/vault-server.md)
+
+The KubeVault operator can manage policies and secret engines of Vault servers which are not provisioned by the KubeVault operator. You need to configure both the Vault server and the cluster so that the KubeVault operator can communicate with your Vault server.
+
+- [Configure cluster and Vault server](/docs/guides/vault-server/external-vault-sever.md#configuration)
+
+Now, we have the [AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md) that contains connection and authentication information about the Vault server. And we also have the service account that the Vault server can authenticate.
+
+```bash
+$ kubectl get appbinding -n demo
+NAME    AGE
+vault   50m
+
+$ kubectl get appbinding -n demo vault -o yaml
+apiVersion: appcatalog.appscode.com/v1alpha1
+kind: AppBinding
+metadata:
+  creationTimestamp: "2021-08-16T08:23:38Z"
+  generation: 1
+  labels:
+    app.kubernetes.io/instance: vault
+    app.kubernetes.io/managed-by: kubevault.com
+    app.kubernetes.io/name: vaultservers.kubevault.com
+  name: vault
+  namespace: demo
+  ownerReferences:
+  - apiVersion: kubevault.com/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: VaultServer
+    name: vault
+    uid: 6b405147-93da-41ff-aad3-29ae9f415d0a
+  resourceVersion: "602898"
+  uid: b54873fd-0f34-42f7-bdf3-4e667edb4659
+spec:
+  clientConfig:
+    service:
+      name: vault
+      port: 8200
+      scheme: http
+  parameters:
+    apiVersion: config.kubevault.com/v1alpha1
+    kind: VaultServerConfiguration
+    kubernetes:
+      serviceAccountName: vault
+      tokenReviewerServiceAccountName: vault-k8s-token-reviewer
+      usePodServiceAccountForCSIDriver: true
+    path: kubernetes
+    vaultRole: vault-policy-controller
+```
+
+## Enable & Configure Microsoft SQL Server SecretEngine
+
+### Enable Microsoft SQL Server SecretEngine
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/mssqlserver/secretengine.yaml
+secretengine.engine.kubevault.com/mssqlserver-engine created
+```
+
+### Create MSSQLServerRole
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/mssqlserver/secretenginerole.yaml
+mssqlserverrole.engine.kubevault.com/mssqlserver-superuser-role created
+```
+
+Let's say pod's service account name is `test-user-account` located in `demo` namespace. We need to create a [VaultPolicy](/docs/concepts/policy-crds/vaultpolicy.md) and a [VaultPolicyBinding](/docs/concepts/policy-crds/vaultpolicybinding.md) so that the pod has access to read secrets from the Vault server.
+
+### Create Service Account for Pod
+
+Let's create the service account `test-user-account` which will be used in VaultPolicyBinding.
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-user-account
+  namespace: demo
+```
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/mssqlserver/serviceaccount.yaml
+serviceaccount/test-user-account created
+
+$ kubectl get serviceaccount -n demo
+NAME                SECRETS   AGE
+test-user-account   1         4h10m
+```
+
+### Create SecretRoleBinding for Pod's Service Account
+
+SecretRoleBinding will create VaultPolicy and VaultPolicyBinding inside vault.
+When a VaultPolicyBinding object is created, the KubeVault operator create an auth role in the Vault server. The role name is generated by the following naming format: `k8s.(clusterName or -).namespace.name`. Here, it is `k8s.kubevault.com.demo.mssqlserver-superuser-role`.
+
+```yaml
+apiVersion: engine.kubevault.com/v1alpha1
+kind: SecretRoleBinding
+metadata:
+  name: secret-role-binding
+  namespace: demo
+spec:
+  roles:
+    - kind: MSSQLServerRole
+      name: mssqlserver-superuser-role
+  subjects:
+    - kind: ServiceAccount
+      name: test-user-account
+      namespace: demo
+```
+
+Let's create SecretRoleBinding:
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/mssqlserver/secretrolebinding.yaml
+secretrolebinding.engine.kubevault.com/secret-role-binding created
+```
+Check if the VaultPolicy and the VaultPolicyBinding are successfully registered to the Vault server:
+
+```bash
+$ kubectl get vaultpolicy -n demo
+NAME                                         STATUS    AGE
+srb-demo-secret-role-binding                 Success   8s
+
+$ kubectl get vaultpolicybinding -n demo
+NAME                                            STATUS    AGE
+srb-demo-secret-role-binding                    Success   10s
+```
+
+## Mount secrets into a Kubernetes pod
+
+So, we can create `SecretProviderClass` now. You can read more about `SecretProviderClass` [here](https://secrets-store-csi-driver.sigs.k8s.io/concepts.html#secretproviderclass).
+
+### Create SecretProviderClass
+
+Create `SecretProviderClass` object with the following content:
+
+```yaml
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: vault-db-provider
+  namespace: demo
+spec:
+  provider: vault
+  parameters:
+    vaultAddress: "http://vault.demo:8200"
+    roleName: "k8s.-.demo.mssqlserver-reader-role"
+    objects: |
+      - objectName: "mssqlserver-creds-username"
+        secretPath: "your-database-path/creds/k8s.-.demo.mssqlserver-superuser-role"
+        secretKey: "username"
+      - objectName: "mssqlserver-creds-password"
+        secretPath: "your-database-path/creds/k8s.-.demo.mssqlserver-superuser-role"
+        secretKey: "password"
+
+```
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/mssqlserver/secretproviderclass.yaml
+secretproviderclass.secrets-store.csi.x-k8s.io/vault-db-provider created
+```
+NOTE: The `SecretProviderClass` needs to be created in the same namespace as the pod.
+
+### Create Pod
+
+Now we can create a `Pod` to consume the `Microsoft SQL Server` secrets. When the `Pod` is created, the `Provider` fetches the secret and writes them to Pod's volume as files. At this point, the volume is successfully mounted and the `Pod` starts running.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-app
+  namespace: demo
+spec:
+  serviceAccountName: test-user-account
+  containers:
+    - image: jweissig/app:0.0.1
+      name: demo-app
+      imagePullPolicy: Always
+      volumeMounts:
+        - name: secrets-store-inline
+          mountPath: "/secrets-store/mssqlserver-creds"
+          readOnly: true
+  volumes:
+    - name: secrets-store-inline
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: "vault-db-provider"
+
+```
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/mssqlserver/pod.yaml
+pod/demo-app created
+```
+## Test & Verify
+
+Check if the Pod is running successfully, by running:
+
+```bash
+$ kubectl get pods -n demo
+NAME                       READY   STATUS    RESTARTS   AGE
+demo-app                   1/1     Running   0          11s
+```
+
+### Verify Secret
+
+If the Pod is running successfully, then check inside the app container by running
+
+```bash
+$ kubectl exec -it -n demo pod/demo-app -- /bin/sh
+/ # ls /secrets-store/mssqlserver-creds
+mssqlserver-creds-password  mssqlserver-creds-username
+
+/ # cat /secrets-store/mssqlserver-creds/mssqlserver-creds-password
+TAu2Zvg1WYE07W8Uf-nW
+
+/ # cat /secrets-store/mssqlserver-creds/mssqlserver-creds-username
+v-kubernetes-test-k8s.-.demo.mssqlserver-s-iPkxiH80Ollq2QgF82Ab-1629178048
+
+/ # exit
+```
+
+So, we can see that the secret `db-username` and `db-password` is mounted into the pod, where the secret key is mounted as file and value is the content of that file.
+
+## Cleaning up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+$ kubectl delete ns demo
+namespace "demo" deleted
+
+```

--- a/docs/guides/secret-engines/mssqlserver/overview.md
+++ b/docs/guides/secret-engines/mssqlserver/overview.md
@@ -1,0 +1,216 @@
+---
+title: Manage Microsoft SQL Server credentials using the KubeVault operator
+menu:
+  docs_{{ .version }}:
+    identifier: overview-mssqlserver
+    name: Overview
+    parent: mssqlserver-secret-engines
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeVault? Please start [here](/docs/concepts/README.md).
+
+# Manage Microsoft SQL Server credentials using the KubeVault operator
+
+OpenBao's [`mssql-database-plugin`](https://github.com/sigilr/openbao/pull/5) is a **dynamic-credentials** database plugin for [Microsoft SQL Server](https://learn.microsoft.com/en-us/sql/relational-databases/security/). The plugin was ported from pre-BUSL HashiCorp Vault using [`microsoft/go-mssqldb`](https://github.com/microsoft/go-mssqldb) and is T-SQL statement based (the same shape PostgreSQL uses): `MSSQLServerRole.spec.creationStatements` is a list of T-SQL statements with `{{name}}` and `{{password}}` placeholders, and credentials are issued dynamically through a `SecretAccessRequest`.
+
+The same CRD shape is used both for the in-process `mssql-database-plugin` and for the hub-spoke `remote-mssql-plugin`; the difference is whether the [Vault AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md) referenced by `SecretEngine.spec.vaultRef` is marked `deploymentMode: RemoteAgent` (then the SecretEngine controller rewrites `plugin_name` to `remote-mssql-plugin` and attaches `spoke_name`).
+
+You need to be familiar with the following CRDs:
+
+- [AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md)
+- [SecretEngine](/docs/concepts/secret-engine-crds/secretengine.md)
+- [MSSQLServerRole](/docs/concepts/secret-engine-crds/database-secret-engine/mssqlserverrole.md)
+
+## Before you begin
+
+- Install KubeVault operator in your cluster from [here](/docs/setup/README.md).
+- Run a Microsoft SQL Server instance the operator can reach over the network. Refer to the SQL Server security docs at https://learn.microsoft.com/en-us/sql/relational-databases/security/ for deployment options.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+## Vault Server
+
+Deploy a Vault Server using the KubeVault operator: [Deploy Vault Server](/docs/guides/vault-server/vault-server.md). The KubeVault operator will create an [AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md) wiring up Kubernetes auth.
+
+```bash
+$ kubectl get appbinding -n demo vault -o yaml
+```
+
+## AppBinding for Microsoft SQL Server
+
+Create an `AppBinding` pointing at the SQL Server database. The URL is a SQL Server DSN (`sqlserver://<user>:<pass>@<host>:1433`); the referenced Secret carries the username and password the plugin uses to log in as the rotation principal.
+
+```yaml
+apiVersion: appcatalog.appscode.com/v1alpha1
+kind: AppBinding
+metadata:
+  name: mssqlserver
+  namespace: demo
+spec:
+  clientConfig:
+    url: sqlserver://mssql.demo.svc:1433
+  secret:
+    name: mssqlserver-cred
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mssqlserver-cred
+  namespace: demo
+type: kubernetes.io/basic-auth
+stringData:
+  username: sa
+  password: change-me
+```
+
+## Enable and Configure Microsoft SQL Server Secret Engine
+
+When a [SecretEngine](/docs/concepts/secret-engine-crds/secretengine.md) crd object is created, the KubeVault operator will enable a secret engine on a specified path and configure the secret engine with the given configuration.
+
+A sample `SecretEngine` for Microsoft SQL Server:
+
+```yaml
+apiVersion: engine.kubevault.com/v1alpha1
+kind: SecretEngine
+metadata:
+  name: mssqlserver-engine
+  namespace: demo
+spec:
+  vaultRef:
+    name: vault
+  mssqlserver:
+    databaseRef:
+      name: mssqlserver
+      namespace: demo
+    pluginName: mssql-database-plugin   # optional; this is the default
+    allowedRoles:
+      - "*"
+    maxOpenConnections: 4
+    maxIdleConnections: 0
+    maxConnectionLifetime: 0s
+    containedDB: false
+```
+
+Set `containedDB: true` to switch the plugin into **contained-database authentication mode** (the plugin runs `CREATE USER ... WITH PASSWORD` against the user database directly). The default `false` keeps the standard behavior of creating logins on `master` and mapping users into the target database. See the SQL Server [contained databases](https://learn.microsoft.com/en-us/sql/relational-databases/databases/contained-databases) docs for the trade-offs.
+
+Apply it and wait for `STATUS=Success`:
+
+```bash
+$ kubectl apply -f mssqlserver-engine.yaml
+secretengine.engine.kubevault.com/mssqlserver-engine created
+
+$ kubectl get secretengines -n demo
+NAME                 STATUS    AGE
+mssqlserver-engine   Success   10s
+```
+
+Use `kubectl describe secretengine -n demo mssqlserver-engine` to inspect error events, if any.
+
+## Create a MSSQLServerRole
+
+A [`MSSQLServerRole`](/docs/concepts/secret-engine-crds/database-secret-engine/mssqlserverrole.md) describes how the plugin should mint a dynamic credential. Each entry in `creationStatements` is a T-SQL statement, executed in sequence with the `{{name}}` and `{{password}}` placeholders substituted at credential-issue time.
+
+```yaml
+apiVersion: engine.kubevault.com/v1alpha1
+kind: MSSQLServerRole
+metadata:
+  name: mssqlserver-readonly
+  namespace: demo
+spec:
+  secretEngineRef:
+    name: mssqlserver-engine
+  creationStatements:
+    - |
+      CREATE LOGIN [{{name}}] WITH PASSWORD = '{{password}}';
+      CREATE USER [{{name}}] FOR LOGIN [{{name}}];
+      GRANT SELECT ON SCHEMA::dbo TO [{{name}}];
+  defaultTTL: 1h
+  maxTTL: 24h
+```
+
+Apply and verify:
+
+```bash
+$ kubectl apply -f mssqlserver-role.yaml
+mssqlserverrole.engine.kubevault.com/mssqlserver-readonly created
+
+$ kubectl get mssqlserverrole -n demo
+NAME                   STATUS    AGE
+mssqlserver-readonly   Success   12s
+```
+
+The role name in Vault follows the format `k8s.{clusterName}.{metadata.namespace}.{metadata.name}`, so you can verify directly with the Vault CLI:
+
+```bash
+$ vault read your-database-path/roles/k8s.-.demo.mssqlserver-readonly
+Key                      Value
+---                      -----
+creation_statements      [CREATE LOGIN [{{name}}] WITH PASSWORD = '{{password}}'; CREATE USER [{{name}}] FOR LOGIN [{{name}}]; GRANT SELECT ON SCHEMA::dbo TO [{{name}}];]
+db_name                  k8s.-.demo.mssqlserver
+default_ttl              1h
+max_ttl                  24h
+```
+
+Deleting the `MSSQLServerRole` removes the role from Vault.
+
+## Issue Microsoft SQL Server credentials
+
+Request a dynamic credential by creating a `SecretAccessRequest`:
+
+```yaml
+apiVersion: engine.kubevault.com/v1alpha1
+kind: SecretAccessRequest
+metadata:
+  name: mssqlserver-cred-rqst
+  namespace: demo
+spec:
+  roleRef:
+    kind: MSSQLServerRole
+    name: mssqlserver-readonly
+  subjects:
+    - kind: ServiceAccount
+      name: demo-sa
+      namespace: demo
+```
+
+Approve it through the KubeVault CLI:
+
+```bash
+$ kubectl vault approve secretaccessrequest mssqlserver-cred-rqst -n demo
+approved
+```
+
+Once approved, the operator issues the credential, stores it in a `Secret`, and binds the listed subjects via a `Role`/`RoleBinding`. The credential lives on the lease until you delete the `SecretAccessRequest` or it expires.
+
+```bash
+$ kubectl get secretaccessrequest mssqlserver-cred-rqst -n demo -o json | jq '.status'
+{
+  "lease": {
+    "duration": "1h0m0s",
+    "id": "your-database-path/creds/k8s.-.demo.mssqlserver-readonly/abc...",
+    "renewable": true
+  },
+  "secret": {
+    "name": "mssqlserver-cred-rqst-xxxxxx"
+  }
+}
+
+$ kubectl get secret -n demo mssqlserver-cred-rqst-xxxxxx -o jsonpath='{.data.username}' | base64 -d
+v-kubernetes-demo-XXXXXXXX
+
+$ kubectl get secret -n demo mssqlserver-cred-rqst-xxxxxx -o jsonpath='{.data.password}' | base64 -d
+xxxxxxxxxxxxxxxxxx
+```
+
+Use the issued `username` / `password` to log in to the SQL Server database; the credential is revoked when the `SecretAccessRequest` is deleted (the plugin runs `revocationStatements`, or falls back to a sensible `DROP LOGIN` / `DROP USER` if you didn't set any).
+
+## Further reading
+
+- Microsoft SQL Server security docs: https://learn.microsoft.com/en-us/sql/relational-databases/security/
+- OpenBao Microsoft SQL Server plugin: https://github.com/sigilr/openbao/pull/5

--- a/docs/guides/secret-engines/mssqlserver/overview.md
+++ b/docs/guides/secret-engines/mssqlserver/overview.md
@@ -22,7 +22,7 @@ You need to be familiar with the following CRDs:
 
 - [AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md)
 - [SecretEngine](/docs/concepts/secret-engine-crds/secretengine.md)
-- [MSSQLServerRole](/docs/concepts/secret-engine-crds/database-secret-engine/mssqlserverrole.md)
+- [MSSQLServerRole](/docs/concepts/secret-engine-crds/database-secret-engine/mssqlserver.md)
 
 ## Before you begin
 
@@ -114,7 +114,7 @@ Use `kubectl describe secretengine -n demo mssqlserver-engine` to inspect error 
 
 ## Create a MSSQLServerRole
 
-A [`MSSQLServerRole`](/docs/concepts/secret-engine-crds/database-secret-engine/mssqlserverrole.md) describes how the plugin should mint a dynamic credential. Each entry in `creationStatements` is a T-SQL statement, executed in sequence with the `{{name}}` and `{{password}}` placeholders substituted at credential-issue time.
+A [`MSSQLServerRole`](/docs/concepts/secret-engine-crds/database-secret-engine/mssqlserver.md) describes how the plugin should mint a dynamic credential. Each entry in `creationStatements` is a T-SQL statement, executed in sequence with the `{{name}}` and `{{password}}` placeholders substituted at credential-issue time.
 
 ```yaml
 apiVersion: engine.kubevault.com/v1alpha1

--- a/docs/guides/secret-engines/mssqlserver/overview.md
+++ b/docs/guides/secret-engines/mssqlserver/overview.md
@@ -56,6 +56,7 @@ spec:
   clientConfig:
     url: sqlserver://mssql.demo.svc:1433
   secret:
+    kind: Secret
     name: mssqlserver-cred
 ---
 apiVersion: v1


### PR DESCRIPTION
User-facing guide for the OpenBao [`mssqlserver-database-plugin`](https://github.com/sigilr/openbao/pull/5) secret engine: AppBinding → SecretEngine → MSSQLServerRole → SecretAccessRequest flow, plugin-specific caveats, and example payloads.

Companion PRs:
- apimachinery (CRDs): kubevault/apimachinery
- operator (reconciler): kubevault/operator

## Test plan
- [ ] Render docs locally and click through the new page