### PR TITLE
docs/guides: add Oracle Database secret engine guide

### DIFF
--- a/docs/concepts/secret-engine-crds/database-secret-engine/oracle.md
+++ b/docs/concepts/secret-engine-crds/database-secret-engine/oracle.md
@@ -130,3 +130,13 @@ rollback a create operation in the event of an error. Not every plugin type will
 - `phase`: Indicates whether the role successfully applied to Vault or not.
 
 - `conditions` : Represent observations of a OracleRole.
+
+## Namespace inheritance (tenant isolation)
+
+A `OracleRole` never sets or resolves an OpenBao namespace itself. It always inherits the
+**effective namespace** of the `SecretEngine` it references via `spec.secretEngineRef`
+(`SecretEngine.status.effectiveNamespace`) — empty for root, or the tenant's OpenBao
+namespace once [tenant isolation](/docs/guides/tenant-isolation/overview.md) has placed
+that engine in one. Every credential this role issues, and every revocation
+(`SecretAccessRequest`), is scoped to that same namespace automatically — no
+`OracleRole`-level configuration is needed.

--- a/docs/concepts/secret-engine-crds/database-secret-engine/oracle.md
+++ b/docs/concepts/secret-engine-crds/database-secret-engine/oracle.md
@@ -1,0 +1,132 @@
+---
+title: OracleRole | Vault Secret Engine
+menu:
+  docs_{{ .version }}:
+    identifier: oraclerole-database-crds
+    name: OracleRole
+    parent: database-crds-concepts
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: concepts
+---
+
+> New to KubeVault? Please start [here](/docs/concepts/README.md).
+
+# OracleRole
+
+## What is OracleRole
+
+A `OracleRole` is a Kubernetes `CustomResourceDefinition` (CRD) which allows a user to create a database secret engine role in a Kubernetes native way.
+
+When a `OracleRole` is created, the KubeVault operator creates a [role](https://www.vaultproject.io/api/secret/databases/index.html#create-role) according to specification.
+If the user deletes the `OracleRole` CRD, then the respective role will also be deleted from Vault.
+
+## OracleRole CRD Specification
+
+Like any official Kubernetes resource, a `OracleRole` object has `TypeMeta`, `ObjectMeta`, `Spec` and `Status` sections.
+
+A sample `OracleRole` object is shown below:
+
+```yaml
+apiVersion: engine.kubevault.com/v1alpha1
+kind: OracleRole
+metadata:
+  name: oracle-role
+  namespace: demo
+spec:
+  secretEngineRef:
+    name: vault-app
+  creationStatements:
+    - "CREATE USER {{name}} IDENTIFIED BY \"{{password}}\";"
+    - "GRANT CONNECT TO {{name}};"
+status:
+  observedGeneration: 1
+  phase: Success
+```
+
+> Note: To resolve the naming conflict, name of the role in Vault will follow this format: `k8s.{clusterName}.{metadata.namespace}.{metadata.name}`
+
+Here, we are going to describe the various sections of the `OracleRole` crd.
+
+### OracleRole Spec
+
+OracleRole `spec` contains information that necessary for creating a database role.
+
+```yaml
+spec:
+  secretEngineRef:
+    name: <vault-appbinding-name>
+  defaultTTL: <default-ttl>
+  maxTTL: <max-ttl>
+  creationStatements:
+    - "statement-0"
+    - "statement-1"
+  revocationStatements:
+    - "statement-0"
+  rollbackStatements:
+    - "statement-0"
+```
+
+OracleRole spec has the following fields:
+
+#### spec.secretEngineRef
+
+`spec.secretEngineRef` is a `required` field that specifies the name of a `SecretEngine`.
+
+```yaml
+spec:
+  secretEngineRef:
+    name: oracle-secret-engine
+```
+
+#### spec.creationStatements
+
+`spec.creationStatements` is a `required` field that specifies a list of database statements executed to create and configure a user.
+The `{{name}}` and `{{password}}` values will be substituted by Vault.
+
+```yaml
+spec:
+  creationStatements:
+    - "CREATE USER {{name}} IDENTIFIED BY \"{{password}}\";"
+    - "GRANT CONNECT TO {{name}};"
+```
+
+#### spec.defaultTTL
+
+`spec.defaultTTL` is an `optional` field that specifies the TTL for the leases associated with this role.
+Accepts time suffixed strings ("1h") or an integer number of seconds. Defaults to system/engine default TTL time.
+
+```yaml
+spec:
+  defaultTTL: "1h"
+```
+
+#### spec.maxTTL
+
+`spec.maxTTL` is an `optional` field that specifies the maximum TTL for the leases associated with this role.
+Accepts time suffixed strings ("1h") or an integer number of seconds. Defaults to system/engine default TTL time.
+
+```yaml
+spec:
+  maxTTL: "1h"
+```
+
+#### spec.revocationStatements
+
+`spec.revocationStatements` is an `optional` field that specifies a list of database statements to be executed to revoke a user. The `{{name}}` value will be substituted. If not provided defaults to a generic drop user statement.
+
+#### spec.rollbackStatements
+
+`spec.rollbackStatements` is an `optional` field that specifies a list of database statements to be executed
+rollback a create operation in the event of an error. Not every plugin type will support this functionality.
+
+### OracleRole Status
+
+`status` shows the status of the OracleRole. It is managed by the KubeVault operator. It contains the following fields:
+
+- `observedGeneration`: Specifies the most recent generation observed for this resource. It corresponds to the resource's generation,
+    which is updated on mutation by the API Server.
+
+- `phase`: Indicates whether the role successfully applied to Vault or not.
+
+- `conditions` : Represent observations of a OracleRole.

--- a/docs/examples/guides/secret-engines/oracle/pod.yaml
+++ b/docs/examples/guides/secret-engines/oracle/pod.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-app
+  namespace: demo
+spec:
+  serviceAccountName: test-user-account
+  containers:
+    - image: jweissig/app:0.0.1
+      name: demo-app
+      imagePullPolicy: Always
+      volumeMounts:
+        - name: secrets-store-inline
+          mountPath: "/secrets-store/oracle-creds"
+          readOnly: true
+  volumes:
+    - name: secrets-store-inline
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: "vault-db-provider"

--- a/docs/examples/guides/secret-engines/oracle/secretengine.yaml
+++ b/docs/examples/guides/secret-engines/oracle/secretengine.yaml
@@ -1,0 +1,18 @@
+apiVersion: engine.kubevault.com/v1alpha1
+kind: SecretEngine
+metadata:
+  name: oracle-engine
+  namespace: demo
+spec:
+  vaultRef:
+    name: vault
+  oracle:
+    databaseRef:
+      name: oracle
+      namespace: demo
+    pluginName: oracle-database-plugin
+    allowedRoles:
+      - "*"
+    maxOpenConnections: 4
+    maxIdleConnections: 0
+    maxConnectionLifetime: 0s

--- a/docs/examples/guides/secret-engines/oracle/secretenginerole.yaml
+++ b/docs/examples/guides/secret-engines/oracle/secretenginerole.yaml
@@ -1,0 +1,16 @@
+apiVersion: engine.kubevault.com/v1alpha1
+kind: OracleRole
+metadata:
+  name: oracle-superuser-role
+  namespace: demo
+spec:
+  secretEngineRef:
+    name: oracle-engine
+  creationStatements:
+    - |
+      CREATE USER {{name}} IDENTIFIED BY "{{password}}";
+      GRANT CONNECT, RESOURCE TO {{name}};
+  revocationStatements:
+    - DROP USER {{name}} CASCADE;
+  defaultTTL: 1h
+  maxTTL: 24h

--- a/docs/examples/guides/secret-engines/oracle/secretproviderclass.yaml
+++ b/docs/examples/guides/secret-engines/oracle/secretproviderclass.yaml
@@ -1,0 +1,17 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: vault-db-provider
+  namespace: demo
+spec:
+  provider: vault
+  parameters:
+    vaultAddress: "http://vault.demo:8200"
+    roleName: "k8s.-.demo.oracle-reader-role"
+    objects: |
+      - objectName: "oracle-creds-username"
+        secretPath: "your-database-path/creds/k8s.-.demo.oracle-superuser-role"
+        secretKey: "username"
+      - objectName: "oracle-creds-password"
+        secretPath: "your-database-path/creds/k8s.-.demo.oracle-superuser-role"
+        secretKey: "password"

--- a/docs/examples/guides/secret-engines/oracle/secretrolebinding.yaml
+++ b/docs/examples/guides/secret-engines/oracle/secretrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: engine.kubevault.com/v1alpha1
+kind: SecretRoleBinding
+metadata:
+  name: secret-role-binding
+  namespace: demo
+spec:
+  roles:
+    - kind: OracleRole
+      name: oracle-superuser-role
+  subjects:
+    - kind: ServiceAccount
+      name: test-user-account
+      namespace: demo

--- a/docs/examples/guides/secret-engines/oracle/serviceaccount.yaml
+++ b/docs/examples/guides/secret-engines/oracle/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-user-account
+  namespace: demo

--- a/docs/guides/hub-spoke/deploy-hub-spoke.md
+++ b/docs/guides/hub-spoke/deploy-hub-spoke.md
@@ -239,7 +239,7 @@ spec:
 
 Because the AppBinding's `deploymentMode` is `RemoteRelay`, the SecretEngine controller configures the hub mount with `plugin_name: remote-postgres-plugin` and `spoke_name: cluster-1`. The hub proxies every credential operation to the spoke relay, which runs the real `postgresql-database-plugin` in-process against the spoke-local database.
 
-Postgres, MySQL, MariaDB, Redis, Valkey, and SQL Server are supported through the spoke relay. MongoDB and Elasticsearch are not; a SecretEngine for those against a `RemoteRelay` AppBinding is rejected on apply by the validating webhook.
+Postgres, MySQL, MariaDB, Redis, Valkey, SQL Server, and Oracle are supported through the spoke relay. MongoDB and Elasticsearch are not; a SecretEngine for those against a `RemoteRelay` AppBinding is rejected on apply by the validating webhook.
 
 Request credentials the usual way with a `SecretAccessRequest`; see the [secret engine guides](/docs/guides/secret-engines/postgres/overview.md).
 

--- a/docs/guides/secret-engines/oracle/_index.md
+++ b/docs/guides/secret-engines/oracle/_index.md
@@ -1,0 +1,10 @@
+---
+title: Oracle Database | Vault Secret Engine
+menu:
+  docs_{{ .version }}:
+    identifier: oracle-secret-engines
+    name: Oracle Database
+    parent: secret-engines-guides
+    weight: 260
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/secret-engines/oracle/csi-driver.md
+++ b/docs/guides/secret-engines/oracle/csi-driver.md
@@ -1,0 +1,291 @@
+---
+title: Mount Oracle Database Secrets using CSI Driver
+menu:
+  docs_{{ .version }}:
+    identifier: csi-driver-oracle
+    name: CSI Driver
+    parent: oracle-secret-engines
+    weight: 15
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+# Mount Oracle Database Secrets using CSI Driver
+
+## Kubernetes Secrets Store CSI Driver
+
+Secrets Store CSI driver for Kubernetes secrets - Integrates secrets stores with Kubernetes via a [Container Storage Interface (CSI)](https://kubernetes-csi.github.io/docs/) volume.
+
+The Secrets Store CSI driver `secrets-store.csi.k8s.io` allows Kubernetes to mount multiple secrets, keys, and certs stored in enterprise-grade external secrets stores into their pods as a volume. Once the Volume is attached, the data in it is mounted into the container’s file system.
+
+![Secrets-store CSI architecture](/docs/guides/secret-engines/csi_architecture.svg)
+
+When the `Pod` is created through the K8s API, it’s scheduled on to a node. The `kubelet` process on the node looks at the pod spec & see if there's any `volumeMount` request. The `kubelet` issues an `RPC` to the `CSI driver` to mount the volume. The `CSI driver` creates & mounts `tmpfs` into the pod. Then the `CSI driver` issues a request to the `Provider`. The provider talks to the external secrets store to fetch the secrets & write them to the pod volume as files. At this point, volume is successfully mounted & the pod starts running.
+
+You can read more about the Kubernetes Secrets Store CSI Driver [here](https://secrets-store-csi-driver.sigs.k8s.io/).
+
+## Consuming Secrets
+
+At first, you need to have a Kubernetes 1.16 or later cluster, and the kubectl command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/). To check the version of your cluster, run:
+
+```bash
+$ kubectl version --short
+Client Version: v1.21.2
+Server Version: v1.21.1
+```
+
+Before you begin:
+
+- Install KubeVault operator in your cluster from [here](/docs/setup/README.md).
+- Install Secrets Store CSI driver for Kubernetes secrets in your cluster from [here](https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation.html).
+- Install Vault Specific CSI provider from [here](https://github.com/hashicorp/vault-csi-provider)
+
+To keep things isolated, we are going to use a separate namespace called `demo` throughout this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> Note: YAML files used in this tutorial stored in [examples](/docs/examples/guides/secret-engines/oracle) folder in GitHub repository [KubeVault/docs](https://github.com/kubevault/kubevault)
+
+## Vault Server
+
+If you don't have a Vault Server, you can deploy it by using the KubeVault operator.
+
+- [Deploy Vault Server](/docs/guides/vault-server/vault-server.md)
+
+The KubeVault operator can manage policies and secret engines of Vault servers which are not provisioned by the KubeVault operator. You need to configure both the Vault server and the cluster so that the KubeVault operator can communicate with your Vault server.
+
+- [Configure cluster and Vault server](/docs/guides/vault-server/external-vault-sever.md#configuration)
+
+Now, we have the [AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md) that contains connection and authentication information about the Vault server. And we also have the service account that the Vault server can authenticate.
+
+```bash
+$ kubectl get appbinding -n demo
+NAME    AGE
+vault   50m
+
+$ kubectl get appbinding -n demo vault -o yaml
+apiVersion: appcatalog.appscode.com/v1alpha1
+kind: AppBinding
+metadata:
+  creationTimestamp: "2021-08-16T08:23:38Z"
+  generation: 1
+  labels:
+    app.kubernetes.io/instance: vault
+    app.kubernetes.io/managed-by: kubevault.com
+    app.kubernetes.io/name: vaultservers.kubevault.com
+  name: vault
+  namespace: demo
+  ownerReferences:
+  - apiVersion: kubevault.com/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: VaultServer
+    name: vault
+    uid: 6b405147-93da-41ff-aad3-29ae9f415d0a
+  resourceVersion: "602898"
+  uid: b54873fd-0f34-42f7-bdf3-4e667edb4659
+spec:
+  clientConfig:
+    service:
+      name: vault
+      port: 8200
+      scheme: http
+  parameters:
+    apiVersion: config.kubevault.com/v1alpha1
+    kind: VaultServerConfiguration
+    kubernetes:
+      serviceAccountName: vault
+      tokenReviewerServiceAccountName: vault-k8s-token-reviewer
+      usePodServiceAccountForCSIDriver: true
+    path: kubernetes
+    vaultRole: vault-policy-controller
+```
+
+## Enable & Configure Oracle Database SecretEngine
+
+### Enable Oracle Database SecretEngine
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/oracle/secretengine.yaml
+secretengine.engine.kubevault.com/oracle-engine created
+```
+
+### Create OracleRole
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/oracle/secretenginerole.yaml
+oraclerole.engine.kubevault.com/oracle-superuser-role created
+```
+
+Let's say pod's service account name is `test-user-account` located in `demo` namespace. We need to create a [VaultPolicy](/docs/concepts/policy-crds/vaultpolicy.md) and a [VaultPolicyBinding](/docs/concepts/policy-crds/vaultpolicybinding.md) so that the pod has access to read secrets from the Vault server.
+
+### Create Service Account for Pod
+
+Let's create the service account `test-user-account` which will be used in VaultPolicyBinding.
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-user-account
+  namespace: demo
+```
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/oracle/serviceaccount.yaml
+serviceaccount/test-user-account created
+
+$ kubectl get serviceaccount -n demo
+NAME                SECRETS   AGE
+test-user-account   1         4h10m
+```
+
+### Create SecretRoleBinding for Pod's Service Account
+
+SecretRoleBinding will create VaultPolicy and VaultPolicyBinding inside vault.
+When a VaultPolicyBinding object is created, the KubeVault operator create an auth role in the Vault server. The role name is generated by the following naming format: `k8s.(clusterName or -).namespace.name`. Here, it is `k8s.kubevault.com.demo.oracle-superuser-role`.
+
+```yaml
+apiVersion: engine.kubevault.com/v1alpha1
+kind: SecretRoleBinding
+metadata:
+  name: secret-role-binding
+  namespace: demo
+spec:
+  roles:
+    - kind: OracleRole
+      name: oracle-superuser-role
+  subjects:
+    - kind: ServiceAccount
+      name: test-user-account
+      namespace: demo
+```
+
+Let's create SecretRoleBinding:
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/oracle/secretrolebinding.yaml
+secretrolebinding.engine.kubevault.com/secret-role-binding created
+```
+Check if the VaultPolicy and the VaultPolicyBinding are successfully registered to the Vault server:
+
+```bash
+$ kubectl get vaultpolicy -n demo
+NAME                                         STATUS    AGE
+srb-demo-secret-role-binding                 Success   8s
+
+$ kubectl get vaultpolicybinding -n demo
+NAME                                            STATUS    AGE
+srb-demo-secret-role-binding                    Success   10s
+```
+
+## Mount secrets into a Kubernetes pod
+
+So, we can create `SecretProviderClass` now. You can read more about `SecretProviderClass` [here](https://secrets-store-csi-driver.sigs.k8s.io/concepts.html#secretproviderclass).
+
+### Create SecretProviderClass
+
+Create `SecretProviderClass` object with the following content:
+
+```yaml
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: vault-db-provider
+  namespace: demo
+spec:
+  provider: vault
+  parameters:
+    vaultAddress: "http://vault.demo:8200"
+    roleName: "k8s.-.demo.oracle-reader-role"
+    objects: |
+      - objectName: "oracle-creds-username"
+        secretPath: "your-database-path/creds/k8s.-.demo.oracle-superuser-role"
+        secretKey: "username"
+      - objectName: "oracle-creds-password"
+        secretPath: "your-database-path/creds/k8s.-.demo.oracle-superuser-role"
+        secretKey: "password"
+
+```
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/oracle/secretproviderclass.yaml
+secretproviderclass.secrets-store.csi.x-k8s.io/vault-db-provider created
+```
+NOTE: The `SecretProviderClass` needs to be created in the same namespace as the pod.
+
+### Create Pod
+
+Now we can create a `Pod` to consume the `Oracle Database` secrets. When the `Pod` is created, the `Provider` fetches the secret and writes them to Pod's volume as files. At this point, the volume is successfully mounted and the `Pod` starts running.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-app
+  namespace: demo
+spec:
+  serviceAccountName: test-user-account
+  containers:
+    - image: jweissig/app:0.0.1
+      name: demo-app
+      imagePullPolicy: Always
+      volumeMounts:
+        - name: secrets-store-inline
+          mountPath: "/secrets-store/oracle-creds"
+          readOnly: true
+  volumes:
+    - name: secrets-store-inline
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: "vault-db-provider"
+
+```
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/oracle/pod.yaml
+pod/demo-app created
+```
+## Test & Verify
+
+Check if the Pod is running successfully, by running:
+
+```bash
+$ kubectl get pods -n demo
+NAME                       READY   STATUS    RESTARTS   AGE
+demo-app                   1/1     Running   0          11s
+```
+
+### Verify Secret
+
+If the Pod is running successfully, then check inside the app container by running
+
+```bash
+$ kubectl exec -it -n demo pod/demo-app -- /bin/sh
+/ # ls /secrets-store/oracle-creds
+oracle-creds-password  oracle-creds-username
+
+/ # cat /secrets-store/oracle-creds/oracle-creds-password
+TAu2Zvg1WYE07W8Uf-nW
+
+/ # cat /secrets-store/oracle-creds/oracle-creds-username
+v-kubernetes-test-k8s.-.demo.oracle-s-iPkxiH80Ollq2QgF82Ab-1629178048
+
+/ # exit
+```
+
+So, we can see that the secret `db-username` and `db-password` is mounted into the pod, where the secret key is mounted as file and value is the content of that file.
+
+## Cleaning up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+$ kubectl delete ns demo
+namespace "demo" deleted
+
+```

--- a/docs/guides/secret-engines/oracle/overview.md
+++ b/docs/guides/secret-engines/oracle/overview.md
@@ -1,0 +1,223 @@
+---
+title: Manage Oracle Database credentials using the KubeVault operator
+menu:
+  docs_{{ .version }}:
+    identifier: overview-oracle
+    name: Overview
+    parent: oracle-secret-engines
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeVault? Please start [here](/docs/concepts/README.md).
+
+# Manage Oracle Database credentials using the KubeVault operator
+
+OpenBao's [`oracle-database-plugin`](https://github.com/sigilr/openbao/pull/6) is a **dynamic-credentials** database plugin for [Oracle Database](https://docs.oracle.com/en/database/). The plugin uses the pure-Go [`sijms/go-ora/v2`](https://github.com/sijms/go-ora) driver, so no Oracle client libraries need to be installed inside the OpenBao container. It is SQL-statement based (the same shape PostgreSQL uses): `OracleRole.spec.creationStatements` is a list of Oracle DDL/DML statements with `{{name}}` and `{{password}}` placeholders, and credentials are issued dynamically through a `SecretAccessRequest`.
+
+> **Expiration is a no-op.** Oracle has no native `VALID UNTIL` clause on users, so the plugin's `UpdateUser` path is intentionally a no-op. Lease expiration still works as normal (the operator issues a new credential when the previous one expires), but you do **not** need to template an `{{expiration}}` placeholder into your `creationStatements` and any `renewStatements` you might be tempted to write would have no effect. To revoke a user before its lease expires, use `revocationStatements` (defaults to `DROP USER {{name}} CASCADE;` if you don't set any).
+
+The same CRD shape is used both for the in-process `oracle-database-plugin` and for the hub-spoke `remote-oracle-plugin`; the difference is whether the [Vault AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md) referenced by `SecretEngine.spec.vaultRef` is marked `deploymentMode: RemoteAgent` (then the SecretEngine controller rewrites `plugin_name` to `remote-oracle-plugin` and attaches `spoke_name`).
+
+You need to be familiar with the following CRDs:
+
+- [AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md)
+- [SecretEngine](/docs/concepts/secret-engine-crds/secretengine.md)
+- [OracleRole](/docs/concepts/secret-engine-crds/database-secret-engine/oraclerole.md)
+
+## Before you begin
+
+- Install KubeVault operator in your cluster from [here](/docs/setup/README.md).
+- Run an Oracle database the operator can reach over the network. Refer to the Oracle Database docs at https://docs.oracle.com/en/database/ for deployment options.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+## Vault Server
+
+Deploy a Vault Server using the KubeVault operator: [Deploy Vault Server](/docs/guides/vault-server/vault-server.md). The KubeVault operator will create an [AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md) wiring up Kubernetes auth.
+
+```bash
+$ kubectl get appbinding -n demo vault -o yaml
+```
+
+## AppBinding for Oracle
+
+Create an `AppBinding` pointing at the Oracle database. The URL is an Oracle DSN that the pure-Go driver understands. Both connect-descriptor and easy-connect forms work, for example:
+
+- `oracle://<user>:<pass>@<host>:1521/<service-name>` — easy-connect with service name (`ORCLCDB`, `XEPDB1`, …).
+- `oracle://<user>:<pass>@<host>:1521/?SID=<sid>` — easy-connect with SID.
+
+The referenced Secret carries the username and password the plugin uses to log in as the rotation principal (it must have privileges to `CREATE USER`, `GRANT`, and `DROP USER`).
+
+```yaml
+apiVersion: appcatalog.appscode.com/v1alpha1
+kind: AppBinding
+metadata:
+  name: oracle
+  namespace: demo
+spec:
+  clientConfig:
+    url: oracle://oracle.demo.svc:1521/ORCLPDB1
+  secret:
+    name: oracle-cred
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oracle-cred
+  namespace: demo
+type: kubernetes.io/basic-auth
+stringData:
+  username: SYSTEM
+  password: change-me
+```
+
+## Enable and Configure Oracle Secret Engine
+
+When a [SecretEngine](/docs/concepts/secret-engine-crds/secretengine.md) crd object is created, the KubeVault operator will enable a secret engine on a specified path and configure the secret engine with the given configuration.
+
+A sample `SecretEngine` for Oracle:
+
+```yaml
+apiVersion: engine.kubevault.com/v1alpha1
+kind: SecretEngine
+metadata:
+  name: oracle-engine
+  namespace: demo
+spec:
+  vaultRef:
+    name: vault
+  oracle:
+    databaseRef:
+      name: oracle
+      namespace: demo
+    pluginName: oracle-database-plugin   # optional; this is the default
+    allowedRoles:
+      - "*"
+    maxOpenConnections: 4
+    maxIdleConnections: 0
+    maxConnectionLifetime: 0s
+```
+
+Apply it and wait for `STATUS=Success`:
+
+```bash
+$ kubectl apply -f oracle-engine.yaml
+secretengine.engine.kubevault.com/oracle-engine created
+
+$ kubectl get secretengines -n demo
+NAME            STATUS    AGE
+oracle-engine   Success   10s
+```
+
+Use `kubectl describe secretengine -n demo oracle-engine` to inspect error events, if any.
+
+## Create an OracleRole
+
+An [`OracleRole`](/docs/concepts/secret-engine-crds/database-secret-engine/oraclerole.md) describes how the plugin should mint a dynamic credential. Each entry in `creationStatements` is an Oracle DDL/DML statement, executed in sequence with the `{{name}}` and `{{password}}` placeholders substituted at credential-issue time. Note that Oracle identifiers are case-sensitive when double-quoted; the plugin issues the user name in upper-case form by default, so leaving `{{name}}` un-quoted is the simplest approach.
+
+```yaml
+apiVersion: engine.kubevault.com/v1alpha1
+kind: OracleRole
+metadata:
+  name: oracle-readonly
+  namespace: demo
+spec:
+  secretEngineRef:
+    name: oracle-engine
+  creationStatements:
+    - |
+      CREATE USER {{name}} IDENTIFIED BY "{{password}}";
+      GRANT CONNECT, RESOURCE TO {{name}};
+  revocationStatements:
+    - DROP USER {{name}} CASCADE;
+  defaultTTL: 1h
+  maxTTL: 24h
+```
+
+Apply and verify:
+
+```bash
+$ kubectl apply -f oracle-role.yaml
+oraclerole.engine.kubevault.com/oracle-readonly created
+
+$ kubectl get oraclerole -n demo
+NAME              STATUS    AGE
+oracle-readonly   Success   12s
+```
+
+The role name in Vault follows the format `k8s.{clusterName}.{metadata.namespace}.{metadata.name}`, so you can verify directly with the Vault CLI:
+
+```bash
+$ vault read your-database-path/roles/k8s.-.demo.oracle-readonly
+Key                      Value
+---                      -----
+creation_statements      [CREATE USER {{name}} IDENTIFIED BY "{{password}}"; GRANT CONNECT, RESOURCE TO {{name}};]
+db_name                  k8s.-.demo.oracle
+default_ttl              1h
+max_ttl                  24h
+revocation_statements    [DROP USER {{name}} CASCADE;]
+```
+
+Deleting the `OracleRole` removes the role from Vault.
+
+## Issue Oracle credentials
+
+Request a dynamic credential by creating a `SecretAccessRequest`:
+
+```yaml
+apiVersion: engine.kubevault.com/v1alpha1
+kind: SecretAccessRequest
+metadata:
+  name: oracle-cred-rqst
+  namespace: demo
+spec:
+  roleRef:
+    kind: OracleRole
+    name: oracle-readonly
+  subjects:
+    - kind: ServiceAccount
+      name: demo-sa
+      namespace: demo
+```
+
+Approve it through the KubeVault CLI:
+
+```bash
+$ kubectl vault approve secretaccessrequest oracle-cred-rqst -n demo
+approved
+```
+
+Once approved, the operator issues the credential, stores it in a `Secret`, and binds the listed subjects via a `Role`/`RoleBinding`. The credential lives on the lease until you delete the `SecretAccessRequest` or it expires.
+
+```bash
+$ kubectl get secretaccessrequest oracle-cred-rqst -n demo -o json | jq '.status'
+{
+  "lease": {
+    "duration": "1h0m0s",
+    "id": "your-database-path/creds/k8s.-.demo.oracle-readonly/abc...",
+    "renewable": true
+  },
+  "secret": {
+    "name": "oracle-cred-rqst-xxxxxx"
+  }
+}
+
+$ kubectl get secret -n demo oracle-cred-rqst-xxxxxx -o jsonpath='{.data.username}' | base64 -d
+V_KUBERNETES_DEMO_XXXXXXXX
+
+$ kubectl get secret -n demo oracle-cred-rqst-xxxxxx -o jsonpath='{.data.password}' | base64 -d
+xxxxxxxxxxxxxxxxxx
+```
+
+Use the issued `username` / `password` to log in to the Oracle database; the credential is revoked when the `SecretAccessRequest` is deleted (the plugin runs `revocationStatements`, or falls back to a `DROP USER {{name}} CASCADE;` if you didn't set any).
+
+## Further reading
+
+- Oracle Database documentation: https://docs.oracle.com/en/database/
+- OpenBao Oracle Database plugin: https://github.com/sigilr/openbao/pull/6
+- `sijms/go-ora` pure-Go Oracle driver: https://github.com/sijms/go-ora

--- a/docs/guides/secret-engines/oracle/overview.md
+++ b/docs/guides/secret-engines/oracle/overview.md
@@ -63,6 +63,7 @@ spec:
   clientConfig:
     url: oracle://oracle.demo.svc:1521/ORCLPDB1
   secret:
+    kind: Secret
     name: oracle-cred
 ---
 apiVersion: v1

--- a/docs/guides/secret-engines/oracle/overview.md
+++ b/docs/guides/secret-engines/oracle/overview.md
@@ -24,7 +24,7 @@ You need to be familiar with the following CRDs:
 
 - [AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md)
 - [SecretEngine](/docs/concepts/secret-engine-crds/secretengine.md)
-- [OracleRole](/docs/concepts/secret-engine-crds/database-secret-engine/oraclerole.md)
+- [OracleRole](/docs/concepts/secret-engine-crds/database-secret-engine/oracle.md)
 
 ## Before you begin
 
@@ -118,7 +118,7 @@ Use `kubectl describe secretengine -n demo oracle-engine` to inspect error event
 
 ## Create an OracleRole
 
-An [`OracleRole`](/docs/concepts/secret-engine-crds/database-secret-engine/oraclerole.md) describes how the plugin should mint a dynamic credential. Each entry in `creationStatements` is an Oracle DDL/DML statement, executed in sequence with the `{{name}}` and `{{password}}` placeholders substituted at credential-issue time. Note that Oracle identifiers are case-sensitive when double-quoted; the plugin issues the user name in upper-case form by default, so leaving `{{name}}` un-quoted is the simplest approach.
+An [`OracleRole`](/docs/concepts/secret-engine-crds/database-secret-engine/oracle.md) describes how the plugin should mint a dynamic credential. Each entry in `creationStatements` is an Oracle DDL/DML statement, executed in sequence with the `{{name}}` and `{{password}}` placeholders substituted at credential-issue time. Note that Oracle identifiers are case-sensitive when double-quoted; the plugin issues the user name in upper-case form by default, so leaving `{{name}}` un-quoted is the simplest approach.
 
 ```yaml
 apiVersion: engine.kubevault.com/v1alpha1


### PR DESCRIPTION
User-facing guide for the OpenBao [`oracle-database-plugin`](https://github.com/sigilr/openbao/pull/6) secret engine: AppBinding → SecretEngine → OracleRole → SecretAccessRequest flow, plugin-specific caveats, and example payloads.

Companion PRs:
- apimachinery (CRDs): kubevault/apimachinery
- operator (reconciler): kubevault/operator

## Test plan
- [ ] Render docs locally and click through the new page