### PR TITLE
docs/guides: add RabbitMQ secret engine guide

### DIFF
--- a/docs/concepts/secret-engine-crds/database-secret-engine/rabbitmq.md
+++ b/docs/concepts/secret-engine-crds/database-secret-engine/rabbitmq.md
@@ -1,0 +1,115 @@
+---
+title: RabbitMQRole | Vault Secret Engine
+menu:
+  docs_{{ .version }}:
+    identifier: rabbitmqrole-database-crds
+    name: RabbitMQRole
+    parent: database-crds-concepts
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: concepts
+---
+
+> New to KubeVault? Please start [here](/docs/concepts/README.md).
+
+# RabbitMQRole
+
+## What is RabbitMQRole
+
+A `RabbitMQRole` is a Kubernetes `CustomResourceDefinition` (CRD) which allows a user to create a database secret engine role in a Kubernetes native way.
+
+When a `RabbitMQRole` is created, the KubeVault operator creates a [role](https://www.vaultproject.io/api/secret/databases/index.html#create-role) according to specification.
+If the user deletes the `RabbitMQRole` CRD, then the respective role will also be deleted from Vault.
+
+## RabbitMQRole CRD Specification
+
+Like any official Kubernetes resource, a `RabbitMQRole` object has `TypeMeta`, `ObjectMeta`, `Spec` and `Status` sections.
+
+A sample `RabbitMQRole` object is shown below:
+
+```yaml
+apiVersion: engine.kubevault.com/v1alpha1
+kind: RabbitMQRole
+metadata:
+  name: rabbitmq-role
+  namespace: demo
+spec:
+  secretEngineRef:
+    name: vault-app
+  creationStatements:
+    - '{"tags":"administrator","vhosts":{"/":{"configure":".*","write":".*","read":".*"}}}'
+status:
+  observedGeneration: 1
+  phase: Success
+```
+
+> Note: To resolve the naming conflict, name of the role in Vault will follow this format: `k8s.{clusterName}.{metadata.namespace}.{metadata.name}`
+
+Here, we are going to describe the various sections of the `RabbitMQRole` crd.
+
+### RabbitMQRole Spec
+
+RabbitMQRole `spec` contains information that necessary for creating a database role.
+
+```yaml
+spec:
+  secretEngineRef:
+    name: <vault-appbinding-name>
+  defaultTTL: <default-ttl>
+  maxTTL: <max-ttl>
+  creationStatements:
+    - "statement-0"
+```
+
+RabbitMQRole spec has the following fields:
+
+#### spec.secretEngineRef
+
+`spec.secretEngineRef` is a `required` field that specifies the name of a `SecretEngine`.
+
+```yaml
+spec:
+  secretEngineRef:
+    name: rabbitmq-secret-engine
+```
+
+#### spec.creationStatements
+
+`spec.creationStatements` is a `required` field that specifies a JSON role document used to provision the user. The exact schema depends on the plugin — see the example below.
+
+```yaml
+spec:
+  creationStatements:
+    - '{"tags":"administrator","vhosts":{"/":{"configure":".*","write":".*","read":".*"}}}'
+```
+
+#### spec.defaultTTL
+
+`spec.defaultTTL` is an `optional` field that specifies the TTL for the leases associated with this role.
+Accepts time suffixed strings ("1h") or an integer number of seconds. Defaults to system/engine default TTL time.
+
+```yaml
+spec:
+  defaultTTL: "1h"
+```
+
+#### spec.maxTTL
+
+`spec.maxTTL` is an `optional` field that specifies the maximum TTL for the leases associated with this role.
+Accepts time suffixed strings ("1h") or an integer number of seconds. Defaults to system/engine default TTL time.
+
+```yaml
+spec:
+  maxTTL: "1h"
+```
+
+### RabbitMQRole Status
+
+`status` shows the status of the RabbitMQRole. It is managed by the KubeVault operator. It contains the following fields:
+
+- `observedGeneration`: Specifies the most recent generation observed for this resource. It corresponds to the resource's generation,
+    which is updated on mutation by the API Server.
+
+- `phase`: Indicates whether the role successfully applied to Vault or not.
+
+- `conditions` : Represent observations of a RabbitMQRole.

--- a/docs/concepts/secret-engine-crds/database-secret-engine/rabbitmq.md
+++ b/docs/concepts/secret-engine-crds/database-secret-engine/rabbitmq.md
@@ -113,3 +113,13 @@ spec:
 - `phase`: Indicates whether the role successfully applied to Vault or not.
 
 - `conditions` : Represent observations of a RabbitMQRole.
+
+## Namespace inheritance (tenant isolation)
+
+A `RabbitMQRole` never sets or resolves an OpenBao namespace itself. It always inherits the
+**effective namespace** of the `SecretEngine` it references via `spec.secretEngineRef`
+(`SecretEngine.status.effectiveNamespace`) — empty for root, or the tenant's OpenBao
+namespace once [tenant isolation](/docs/guides/tenant-isolation/overview.md) has placed
+that engine in one. Every credential this role issues, and every revocation
+(`SecretAccessRequest`), is scoped to that same namespace automatically — no
+`RabbitMQRole`-level configuration is needed.

--- a/docs/examples/guides/secret-engines/rabbitmq/pod.yaml
+++ b/docs/examples/guides/secret-engines/rabbitmq/pod.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-app
+  namespace: demo
+spec:
+  serviceAccountName: test-user-account
+  containers:
+    - image: jweissig/app:0.0.1
+      name: demo-app
+      imagePullPolicy: Always
+      volumeMounts:
+        - name: secrets-store-inline
+          mountPath: "/secrets-store/rabbitmq-creds"
+          readOnly: true
+  volumes:
+    - name: secrets-store-inline
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: "vault-db-provider"

--- a/docs/examples/guides/secret-engines/rabbitmq/secretengine.yaml
+++ b/docs/examples/guides/secret-engines/rabbitmq/secretengine.yaml
@@ -1,0 +1,15 @@
+apiVersion: engine.kubevault.com/v1alpha1
+kind: SecretEngine
+metadata:
+  name: rabbitmq-engine
+  namespace: demo
+spec:
+  vaultRef:
+    name: vault
+  rabbitmq:
+    databaseRef:
+      name: rabbitmq
+      namespace: demo
+    pluginName: rabbitmq-database-plugin
+    allowedRoles:
+      - "*"

--- a/docs/examples/guides/secret-engines/rabbitmq/secretenginerole.yaml
+++ b/docs/examples/guides/secret-engines/rabbitmq/secretenginerole.yaml
@@ -1,0 +1,12 @@
+apiVersion: engine.kubevault.com/v1alpha1
+kind: RabbitMQRole
+metadata:
+  name: rabbitmq-superuser-role
+  namespace: demo
+spec:
+  secretEngineRef:
+    name: rabbitmq-engine
+  creationStatements:
+    - '{"tags":"administrator","vhosts":{"/":{"configure":".*","write":".*","read":".*"}}}'
+  defaultTTL: 1h
+  maxTTL: 24h

--- a/docs/examples/guides/secret-engines/rabbitmq/secretproviderclass.yaml
+++ b/docs/examples/guides/secret-engines/rabbitmq/secretproviderclass.yaml
@@ -1,0 +1,17 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: vault-db-provider
+  namespace: demo
+spec:
+  provider: vault
+  parameters:
+    vaultAddress: "http://vault.demo:8200"
+    roleName: "k8s.-.demo.rabbitmq-reader-role"
+    objects: |
+      - objectName: "rabbitmq-creds-username"
+        secretPath: "your-database-path/creds/k8s.-.demo.rabbitmq-superuser-role"
+        secretKey: "username"
+      - objectName: "rabbitmq-creds-password"
+        secretPath: "your-database-path/creds/k8s.-.demo.rabbitmq-superuser-role"
+        secretKey: "password"

--- a/docs/examples/guides/secret-engines/rabbitmq/secretrolebinding.yaml
+++ b/docs/examples/guides/secret-engines/rabbitmq/secretrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: engine.kubevault.com/v1alpha1
+kind: SecretRoleBinding
+metadata:
+  name: secret-role-binding
+  namespace: demo
+spec:
+  roles:
+    - kind: RabbitMQRole
+      name: rabbitmq-superuser-role
+  subjects:
+    - kind: ServiceAccount
+      name: test-user-account
+      namespace: demo

--- a/docs/examples/guides/secret-engines/rabbitmq/serviceaccount.yaml
+++ b/docs/examples/guides/secret-engines/rabbitmq/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-user-account
+  namespace: demo

--- a/docs/guides/hub-spoke/deploy-hub-spoke.md
+++ b/docs/guides/hub-spoke/deploy-hub-spoke.md
@@ -239,7 +239,7 @@ spec:
 
 Because the AppBinding's `deploymentMode` is `RemoteRelay`, the SecretEngine controller configures the hub mount with `plugin_name: remote-postgres-plugin` and `spoke_name: cluster-1`. The hub proxies every credential operation to the spoke relay, which runs the real `postgresql-database-plugin` in-process against the spoke-local database.
 
-Postgres, MySQL, MariaDB, Redis, Valkey, SQL Server, and Oracle are supported through the spoke relay. MongoDB and Elasticsearch are not; a SecretEngine for those against a `RemoteRelay` AppBinding is rejected on apply by the validating webhook.
+Postgres, MySQL, MariaDB, Redis, Valkey, SQL Server, Oracle, and RabbitMQ are supported through the spoke relay. MongoDB and Elasticsearch are not; a SecretEngine for those against a `RemoteRelay` AppBinding is rejected on apply by the validating webhook.
 
 Request credentials the usual way with a `SecretAccessRequest`; see the [secret engine guides](/docs/guides/secret-engines/postgres/overview.md).
 

--- a/docs/guides/secret-engines/rabbitmq/_index.md
+++ b/docs/guides/secret-engines/rabbitmq/_index.md
@@ -1,0 +1,10 @@
+---
+title: RabbitMQ | Vault Secret Engine
+menu:
+  docs_{{ .version }}:
+    identifier: rabbitmq-secret-engines
+    name: RabbitMQ
+    parent: secret-engines-guides
+    weight: 280
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/secret-engines/rabbitmq/csi-driver.md
+++ b/docs/guides/secret-engines/rabbitmq/csi-driver.md
@@ -1,0 +1,291 @@
+---
+title: Mount RabbitMQ Secrets using CSI Driver
+menu:
+  docs_{{ .version }}:
+    identifier: csi-driver-rabbitmq
+    name: CSI Driver
+    parent: rabbitmq-secret-engines
+    weight: 15
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+# Mount RabbitMQ Secrets using CSI Driver
+
+## Kubernetes Secrets Store CSI Driver
+
+Secrets Store CSI driver for Kubernetes secrets - Integrates secrets stores with Kubernetes via a [Container Storage Interface (CSI)](https://kubernetes-csi.github.io/docs/) volume.
+
+The Secrets Store CSI driver `secrets-store.csi.k8s.io` allows Kubernetes to mount multiple secrets, keys, and certs stored in enterprise-grade external secrets stores into their pods as a volume. Once the Volume is attached, the data in it is mounted into the container’s file system.
+
+![Secrets-store CSI architecture](/docs/guides/secret-engines/csi_architecture.svg)
+
+When the `Pod` is created through the K8s API, it’s scheduled on to a node. The `kubelet` process on the node looks at the pod spec & see if there's any `volumeMount` request. The `kubelet` issues an `RPC` to the `CSI driver` to mount the volume. The `CSI driver` creates & mounts `tmpfs` into the pod. Then the `CSI driver` issues a request to the `Provider`. The provider talks to the external secrets store to fetch the secrets & write them to the pod volume as files. At this point, volume is successfully mounted & the pod starts running.
+
+You can read more about the Kubernetes Secrets Store CSI Driver [here](https://secrets-store-csi-driver.sigs.k8s.io/).
+
+## Consuming Secrets
+
+At first, you need to have a Kubernetes 1.16 or later cluster, and the kubectl command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/). To check the version of your cluster, run:
+
+```bash
+$ kubectl version --short
+Client Version: v1.21.2
+Server Version: v1.21.1
+```
+
+Before you begin:
+
+- Install KubeVault operator in your cluster from [here](/docs/setup/README.md).
+- Install Secrets Store CSI driver for Kubernetes secrets in your cluster from [here](https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation.html).
+- Install Vault Specific CSI provider from [here](https://github.com/hashicorp/vault-csi-provider)
+
+To keep things isolated, we are going to use a separate namespace called `demo` throughout this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> Note: YAML files used in this tutorial stored in [examples](/docs/examples/guides/secret-engines/rabbitmq) folder in GitHub repository [KubeVault/docs](https://github.com/kubevault/kubevault)
+
+## Vault Server
+
+If you don't have a Vault Server, you can deploy it by using the KubeVault operator.
+
+- [Deploy Vault Server](/docs/guides/vault-server/vault-server.md)
+
+The KubeVault operator can manage policies and secret engines of Vault servers which are not provisioned by the KubeVault operator. You need to configure both the Vault server and the cluster so that the KubeVault operator can communicate with your Vault server.
+
+- [Configure cluster and Vault server](/docs/guides/vault-server/external-vault-sever.md#configuration)
+
+Now, we have the [AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md) that contains connection and authentication information about the Vault server. And we also have the service account that the Vault server can authenticate.
+
+```bash
+$ kubectl get appbinding -n demo
+NAME    AGE
+vault   50m
+
+$ kubectl get appbinding -n demo vault -o yaml
+apiVersion: appcatalog.appscode.com/v1alpha1
+kind: AppBinding
+metadata:
+  creationTimestamp: "2021-08-16T08:23:38Z"
+  generation: 1
+  labels:
+    app.kubernetes.io/instance: vault
+    app.kubernetes.io/managed-by: kubevault.com
+    app.kubernetes.io/name: vaultservers.kubevault.com
+  name: vault
+  namespace: demo
+  ownerReferences:
+  - apiVersion: kubevault.com/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: VaultServer
+    name: vault
+    uid: 6b405147-93da-41ff-aad3-29ae9f415d0a
+  resourceVersion: "602898"
+  uid: b54873fd-0f34-42f7-bdf3-4e667edb4659
+spec:
+  clientConfig:
+    service:
+      name: vault
+      port: 8200
+      scheme: http
+  parameters:
+    apiVersion: config.kubevault.com/v1alpha1
+    kind: VaultServerConfiguration
+    kubernetes:
+      serviceAccountName: vault
+      tokenReviewerServiceAccountName: vault-k8s-token-reviewer
+      usePodServiceAccountForCSIDriver: true
+    path: kubernetes
+    vaultRole: vault-policy-controller
+```
+
+## Enable & Configure RabbitMQ SecretEngine
+
+### Enable RabbitMQ SecretEngine
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/rabbitmq/secretengine.yaml
+secretengine.engine.kubevault.com/rabbitmq-engine created
+```
+
+### Create RabbitMQRole
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/rabbitmq/secretenginerole.yaml
+rabbitmqrole.engine.kubevault.com/rabbitmq-superuser-role created
+```
+
+Let's say pod's service account name is `test-user-account` located in `demo` namespace. We need to create a [VaultPolicy](/docs/concepts/policy-crds/vaultpolicy.md) and a [VaultPolicyBinding](/docs/concepts/policy-crds/vaultpolicybinding.md) so that the pod has access to read secrets from the Vault server.
+
+### Create Service Account for Pod
+
+Let's create the service account `test-user-account` which will be used in VaultPolicyBinding.
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-user-account
+  namespace: demo
+```
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/rabbitmq/serviceaccount.yaml
+serviceaccount/test-user-account created
+
+$ kubectl get serviceaccount -n demo
+NAME                SECRETS   AGE
+test-user-account   1         4h10m
+```
+
+### Create SecretRoleBinding for Pod's Service Account
+
+SecretRoleBinding will create VaultPolicy and VaultPolicyBinding inside vault.
+When a VaultPolicyBinding object is created, the KubeVault operator create an auth role in the Vault server. The role name is generated by the following naming format: `k8s.(clusterName or -).namespace.name`. Here, it is `k8s.kubevault.com.demo.rabbitmq-superuser-role`.
+
+```yaml
+apiVersion: engine.kubevault.com/v1alpha1
+kind: SecretRoleBinding
+metadata:
+  name: secret-role-binding
+  namespace: demo
+spec:
+  roles:
+    - kind: RabbitMQRole
+      name: rabbitmq-superuser-role
+  subjects:
+    - kind: ServiceAccount
+      name: test-user-account
+      namespace: demo
+```
+
+Let's create SecretRoleBinding:
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/rabbitmq/secretrolebinding.yaml
+secretrolebinding.engine.kubevault.com/secret-role-binding created
+```
+Check if the VaultPolicy and the VaultPolicyBinding are successfully registered to the Vault server:
+
+```bash
+$ kubectl get vaultpolicy -n demo
+NAME                                         STATUS    AGE
+srb-demo-secret-role-binding                 Success   8s
+
+$ kubectl get vaultpolicybinding -n demo
+NAME                                            STATUS    AGE
+srb-demo-secret-role-binding                    Success   10s
+```
+
+## Mount secrets into a Kubernetes pod
+
+So, we can create `SecretProviderClass` now. You can read more about `SecretProviderClass` [here](https://secrets-store-csi-driver.sigs.k8s.io/concepts.html#secretproviderclass).
+
+### Create SecretProviderClass
+
+Create `SecretProviderClass` object with the following content:
+
+```yaml
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: vault-db-provider
+  namespace: demo
+spec:
+  provider: vault
+  parameters:
+    vaultAddress: "http://vault.demo:8200"
+    roleName: "k8s.-.demo.rabbitmq-reader-role"
+    objects: |
+      - objectName: "rabbitmq-creds-username"
+        secretPath: "your-database-path/creds/k8s.-.demo.rabbitmq-superuser-role"
+        secretKey: "username"
+      - objectName: "rabbitmq-creds-password"
+        secretPath: "your-database-path/creds/k8s.-.demo.rabbitmq-superuser-role"
+        secretKey: "password"
+
+```
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/rabbitmq/secretproviderclass.yaml
+secretproviderclass.secrets-store.csi.x-k8s.io/vault-db-provider created
+```
+NOTE: The `SecretProviderClass` needs to be created in the same namespace as the pod.
+
+### Create Pod
+
+Now we can create a `Pod` to consume the `RabbitMQ` secrets. When the `Pod` is created, the `Provider` fetches the secret and writes them to Pod's volume as files. At this point, the volume is successfully mounted and the `Pod` starts running.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-app
+  namespace: demo
+spec:
+  serviceAccountName: test-user-account
+  containers:
+    - image: jweissig/app:0.0.1
+      name: demo-app
+      imagePullPolicy: Always
+      volumeMounts:
+        - name: secrets-store-inline
+          mountPath: "/secrets-store/rabbitmq-creds"
+          readOnly: true
+  volumes:
+    - name: secrets-store-inline
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: "vault-db-provider"
+
+```
+
+```bash
+$ kubectl apply -f docs/examples/guides/secret-engines/rabbitmq/pod.yaml
+pod/demo-app created
+```
+## Test & Verify
+
+Check if the Pod is running successfully, by running:
+
+```bash
+$ kubectl get pods -n demo
+NAME                       READY   STATUS    RESTARTS   AGE
+demo-app                   1/1     Running   0          11s
+```
+
+### Verify Secret
+
+If the Pod is running successfully, then check inside the app container by running
+
+```bash
+$ kubectl exec -it -n demo pod/demo-app -- /bin/sh
+/ # ls /secrets-store/rabbitmq-creds
+rabbitmq-creds-password  rabbitmq-creds-username
+
+/ # cat /secrets-store/rabbitmq-creds/rabbitmq-creds-password
+TAu2Zvg1WYE07W8Uf-nW
+
+/ # cat /secrets-store/rabbitmq-creds/rabbitmq-creds-username
+v-kubernetes-test-k8s.-.demo.rabbitmq-s-iPkxiH80Ollq2QgF82Ab-1629178048
+
+/ # exit
+```
+
+So, we can see that the secret `db-username` and `db-password` is mounted into the pod, where the secret key is mounted as file and value is the content of that file.
+
+## Cleaning up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+$ kubectl delete ns demo
+namespace "demo" deleted
+
+```

--- a/docs/guides/secret-engines/rabbitmq/overview.md
+++ b/docs/guides/secret-engines/rabbitmq/overview.md
@@ -1,0 +1,221 @@
+---
+title: Manage RabbitMQ credentials using the KubeVault operator
+menu:
+  docs_{{ .version }}:
+    identifier: overview-rabbitmq
+    name: Overview
+    parent: rabbitmq-secret-engines
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeVault? Please start [here](/docs/concepts/README.md).
+
+# Manage RabbitMQ credentials using the KubeVault operator
+
+OpenBao's [`rabbitmq-database-plugin`](https://github.com/sigilr/openbao/pull/8) is a **dynamic-credentials** database plugin for [RabbitMQ](https://www.rabbitmq.com/). The plugin provisions credentials via the [RabbitMQ Management HTTP API](https://www.rabbitmq.com/management.html) (using [`rabbit-hole/v3`](https://github.com/michaelklishin/rabbit-hole)). Each issued credential becomes a native RabbitMQ user whose `tags`, per-vhost permissions, and (optionally) per-topic permissions are taken from the `creationStatements` JSON role document. On lease revocation the plugin deletes the user with `DELETE /api/users/<name>`, which is naturally idempotent — so there is no `revocation_statements` field on the `RabbitMQRole`.
+
+The same CRD shape is used both for the in-process `rabbitmq-database-plugin` and for the hub-spoke `remote-rabbitmq-plugin`; the difference is whether the [Vault AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md) referenced by `SecretEngine.spec.vaultRef` is marked `deploymentMode: RemoteAgent` (then the SecretEngine controller rewrites `plugin_name` to `remote-rabbitmq-plugin` and attaches `spoke_name`).
+
+You need to be familiar with the following CRDs:
+
+- [AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md)
+- [SecretEngine](/docs/concepts/secret-engine-crds/secretengine.md)
+- [RabbitMQRole](/docs/concepts/secret-engine-crds/database-secret-engine/rabbitmqrole.md)
+
+## Before you begin
+
+- Install KubeVault operator in your cluster from [here](/docs/setup/README.md).
+- Run a RabbitMQ cluster with the [management plugin](https://www.rabbitmq.com/management.html) enabled. The official `rabbitmq:3-management` Docker image exposes the HTTP API at `15672`.
+- Have an administrator user on RabbitMQ (the default `guest`/`guest` works for `localhost`-only setups; create a real admin for production). The plugin authenticates against the management API as this user when issuing credential operations.
+- Decide which RabbitMQ [tags and per-vhost permissions](https://www.rabbitmq.com/access-control.html) the dynamic users should receive (e.g. `administrator`, or per-vhost `configure`/`write`/`read` regex permissions).
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+## Vault Server
+
+Deploy a Vault Server using the KubeVault operator: [Deploy Vault Server](/docs/guides/vault-server/vault-server.md). The KubeVault operator will create an [AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md) wiring up Kubernetes auth.
+
+```bash
+$ kubectl get appbinding -n demo vault -o yaml
+```
+
+## AppBinding for RabbitMQ
+
+Create an `AppBinding` pointing at the RabbitMQ **management HTTP API** base URL (e.g. `http://rabbitmq.demo.svc:15672`). Unlike most database engines, the URL here is **not** an AMQP URI — it is the management plugin's HTTP base URL, which `rabbit-hole/v3` uses to call the REST endpoints. The referenced Secret carries HTTP Basic Auth credentials (`username` + `password`) used by the plugin to authenticate against the management API.
+
+```yaml
+apiVersion: appcatalog.appscode.com/v1alpha1
+kind: AppBinding
+metadata:
+  name: rabbitmq
+  namespace: demo
+spec:
+  clientConfig:
+    url: http://rabbitmq.demo.svc:15672
+  secret:
+    name: rabbitmq-cred
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rabbitmq-cred
+  namespace: demo
+type: kubernetes.io/basic-auth
+stringData:
+  username: admin
+  password: admin-password
+```
+
+> If your RabbitMQ management endpoint uses a self-signed TLS certificate (`https://...:15671`), set `SecretEngine.spec.rabbitmq.insecure: true` below. Drop the knob once you front the management API with a real CA-issued certificate.
+
+## Enable and Configure RabbitMQ Secret Engine
+
+When a [SecretEngine](/docs/concepts/secret-engine-crds/secretengine.md) crd object is created, the KubeVault operator will enable a secret engine on a specified path and configure the secret engine with the given configuration.
+
+A sample `SecretEngine` for RabbitMQ:
+
+```yaml
+apiVersion: engine.kubevault.com/v1alpha1
+kind: SecretEngine
+metadata:
+  name: rabbitmq-engine
+  namespace: demo
+spec:
+  vaultRef:
+    name: vault
+  rabbitmq:
+    databaseRef:
+      name: rabbitmq
+      namespace: demo
+    pluginName: rabbitmq-database-plugin   # optional; this is the default
+    allowedRoles:
+      - "*"
+    # passwordPolicy: my-policy            # optional; name of a Vault password policy
+    insecure: false                        # set true only for self-signed dev clusters
+```
+
+Apply it and wait for `STATUS=Success`:
+
+```bash
+$ kubectl apply -f rabbitmq-engine.yaml
+secretengine.engine.kubevault.com/rabbitmq-engine created
+
+$ kubectl get secretengines -n demo
+NAME              STATUS    AGE
+rabbitmq-engine   Success   10s
+```
+
+Use `kubectl describe secretengine -n demo rabbitmq-engine` to inspect error events, if any.
+
+## Create a RabbitMQRole
+
+A [`RabbitMQRole`](/docs/concepts/secret-engine-crds/database-secret-engine/rabbitmqrole.md) describes how the plugin should mint a dynamic credential. `creationStatements` is a single-element string slice holding a JSON role document with any combination of `tags`, `vhosts`, and `vhost_topics`. **At least one of `tags` or `vhosts` must be set.** The `vhosts` map keys are RabbitMQ vhost names (`/` is the default vhost) and each value is the standard RabbitMQ permission triple (`configure` / `write` / `read` regular expressions). See [Access Control](https://www.rabbitmq.com/access-control.html) for the full RabbitMQ authorization model.
+
+```yaml
+apiVersion: engine.kubevault.com/v1alpha1
+kind: RabbitMQRole
+metadata:
+  name: rabbitmq-admin
+  namespace: demo
+spec:
+  secretEngineRef:
+    name: rabbitmq-engine
+  creationStatements:
+    - '{"tags":"administrator","vhosts":{"/":{"configure":".*","write":".*","read":".*"}}}'
+  defaultTTL: 1h
+  maxTTL: 24h
+```
+
+A more scoped example that grants only publish/consume on a single vhost (no broker administration):
+
+```yaml
+spec:
+  creationStatements:
+    - '{"vhosts":{"/app":{"configure":"^$","write":"^events\\.","read":"^events\\."}}}'
+```
+
+Apply and verify:
+
+```bash
+$ kubectl apply -f rabbitmq-role.yaml
+rabbitmqrole.engine.kubevault.com/rabbitmq-admin created
+
+$ kubectl get rabbitmqrole -n demo
+NAME             STATUS    AGE
+rabbitmq-admin   Success   12s
+```
+
+The role name in Vault follows the format `k8s.{clusterName}.{metadata.namespace}.{metadata.name}`, so you can verify directly with the Vault CLI:
+
+```bash
+$ vault read your-database-path/roles/k8s.-.demo.rabbitmq-admin
+Key                      Value
+---                      -----
+creation_statements      [{"tags":"administrator","vhosts":{"/":{"configure":".*","write":".*","read":".*"}}}]
+db_name                  k8s.-.demo.rabbitmq
+default_ttl              1h
+max_ttl                  24h
+```
+
+Deleting the `RabbitMQRole` removes the role from Vault.
+
+## Issue RabbitMQ credentials
+
+Request a dynamic credential by creating a `SecretAccessRequest`:
+
+```yaml
+apiVersion: engine.kubevault.com/v1alpha1
+kind: SecretAccessRequest
+metadata:
+  name: rabbitmq-cred-rqst
+  namespace: demo
+spec:
+  roleRef:
+    kind: RabbitMQRole
+    name: rabbitmq-admin
+  subjects:
+    - kind: ServiceAccount
+      name: demo-sa
+      namespace: demo
+```
+
+Approve it through the KubeVault CLI:
+
+```bash
+$ kubectl vault approve secretaccessrequest rabbitmq-cred-rqst -n demo
+approved
+```
+
+Once approved, the operator issues the credential, stores it in a `Secret`, and binds the listed subjects via a `Role`/`RoleBinding`. Internally the plugin calls `PUT /api/users/<name>` to create the user with the generated password, then `PUT /api/users/<name>/...` to apply `tags` and per-vhost permissions exactly as listed in the `creationStatements` JSON. The credential lives on the lease until you delete the `SecretAccessRequest` or it expires; on lease revocation the plugin calls `DELETE /api/users/<name>` (idempotent — so revocation works even if the user has already been removed out-of-band, and no `revocation_statements` are required on the `RabbitMQRole`).
+
+```bash
+$ kubectl get secretaccessrequest rabbitmq-cred-rqst -n demo -o json | jq '.status'
+{
+  "lease": {
+    "duration": "1h0m0s",
+    "id": "your-database-path/creds/k8s.-.demo.rabbitmq-admin/abc...",
+    "renewable": true
+  },
+  "secret": {
+    "name": "rabbitmq-cred-rqst-xxxxxx"
+  }
+}
+
+$ kubectl get secret -n demo rabbitmq-cred-rqst-xxxxxx -o jsonpath='{.data.username}' | base64 -d
+v-kubernetes-demo-XXXXXXXX
+
+$ kubectl get secret -n demo rabbitmq-cred-rqst-xxxxxx -o jsonpath='{.data.password}' | base64 -d
+xxxxxxxxxxxxxxxxxx
+```
+
+Use the issued `username` / `password` to open an AMQP connection against your RabbitMQ cluster (or hit the management API). The credential is revoked when the `SecretAccessRequest` is deleted.
+
+## Further reading
+
+- RabbitMQ access control: https://www.rabbitmq.com/access-control.html
+- OpenBao RabbitMQ plugin: https://github.com/sigilr/openbao/pull/8

--- a/docs/guides/secret-engines/rabbitmq/overview.md
+++ b/docs/guides/secret-engines/rabbitmq/overview.md
@@ -46,7 +46,7 @@ $ kubectl get appbinding -n demo vault -o yaml
 
 ## AppBinding for RabbitMQ
 
-Create an `AppBinding` pointing at the RabbitMQ **management HTTP API** base URL (e.g. `http://rabbitmq.demo.svc:15672`). Unlike most database engines, the URL here is **not** an AMQP URI — it is the management plugin's HTTP base URL, which `rabbit-hole/v3` uses to call the REST endpoints. The referenced Secret carries HTTP Basic Auth credentials (`username` + `password`) used by the plugin to authenticate against the management API.
+Create an `AppBinding` pointing at the RabbitMQ **management HTTP API** base URL (e.g. `http://rabbitmq.demo.svc:15672`). Unlike most database engines, the URL here is **not** an AMQP URI — it is the management plugin's HTTP base URL, which `rabbit-hole/v3` uses to call the REST endpoints. The referenced Secret carries HTTP Basic Auth credentials (`username` + `password`) used by the plugin to authenticate against the management API. If the management API is served over TLS with a certificate signed by a private CA, set `spec.clientConfig.caBundle` to the PEM-encoded CA certificate — the operator forwards it to the plugin as `tls_ca` for server-certificate verification.
 
 ```yaml
 apiVersion: appcatalog.appscode.com/v1alpha1
@@ -71,7 +71,7 @@ stringData:
   password: admin-password
 ```
 
-> If your RabbitMQ management endpoint uses a self-signed TLS certificate (`https://...:15671`), set `SecretEngine.spec.rabbitmq.insecure: true` below. Drop the knob once you front the management API with a real CA-issued certificate.
+> If your RabbitMQ management endpoint uses a self-signed TLS certificate (`https://...:15671`), either set the `AppBinding`'s `spec.clientConfig.caBundle` to the CA that signed it (preferred — verifies the certificate), or set `SecretEngine.spec.rabbitmq.insecure: true` below to skip verification entirely. Drop `insecure` once you front the management API with a CA-issued (or CA-bundle-verified) certificate. If the management API requires mutual TLS, set `SecretEngine.spec.rabbitmq.clientCert`/`clientKey` to a PEM-encoded client certificate and private key.
 
 ## Enable and Configure RabbitMQ Secret Engine
 
@@ -96,6 +96,14 @@ spec:
     allowedRoles:
       - "*"
     # passwordPolicy: my-policy            # optional; name of a Vault password policy
+    # clientCert: |                        # optional; PEM-encoded client cert for mutual TLS
+    #   -----BEGIN CERTIFICATE-----
+    #   ...
+    #   -----END CERTIFICATE-----
+    # clientKey: |                         # optional; PEM-encoded private key for clientCert
+    #   -----BEGIN PRIVATE KEY-----
+    #   ...
+    #   -----END PRIVATE KEY-----
     insecure: false                        # set true only for self-signed dev clusters
 ```
 

--- a/docs/guides/secret-engines/rabbitmq/overview.md
+++ b/docs/guides/secret-engines/rabbitmq/overview.md
@@ -58,6 +58,7 @@ spec:
   clientConfig:
     url: http://rabbitmq.demo.svc:15672
   secret:
+    kind: Secret
     name: rabbitmq-cred
 ---
 apiVersion: v1

--- a/docs/guides/secret-engines/rabbitmq/overview.md
+++ b/docs/guides/secret-engines/rabbitmq/overview.md
@@ -22,7 +22,7 @@ You need to be familiar with the following CRDs:
 
 - [AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md)
 - [SecretEngine](/docs/concepts/secret-engine-crds/secretengine.md)
-- [RabbitMQRole](/docs/concepts/secret-engine-crds/database-secret-engine/rabbitmqrole.md)
+- [RabbitMQRole](/docs/concepts/secret-engine-crds/database-secret-engine/rabbitmq.md)
 
 ## Before you begin
 
@@ -122,7 +122,7 @@ Use `kubectl describe secretengine -n demo rabbitmq-engine` to inspect error eve
 
 ## Create a RabbitMQRole
 
-A [`RabbitMQRole`](/docs/concepts/secret-engine-crds/database-secret-engine/rabbitmqrole.md) describes how the plugin should mint a dynamic credential. `creationStatements` is a single-element string slice holding a JSON role document with any combination of `tags`, `vhosts`, and `vhost_topics`. **At least one of `tags` or `vhosts` must be set.** The `vhosts` map keys are RabbitMQ vhost names (`/` is the default vhost) and each value is the standard RabbitMQ permission triple (`configure` / `write` / `read` regular expressions). See [Access Control](https://www.rabbitmq.com/access-control.html) for the full RabbitMQ authorization model.
+A [`RabbitMQRole`](/docs/concepts/secret-engine-crds/database-secret-engine/rabbitmq.md) describes how the plugin should mint a dynamic credential. `creationStatements` is a single-element string slice holding a JSON role document with any combination of `tags`, `vhosts`, and `vhost_topics`. **At least one of `tags` or `vhosts` must be set.** The `vhosts` map keys are RabbitMQ vhost names (`/` is the default vhost) and each value is the standard RabbitMQ permission triple (`configure` / `write` / `read` regular expressions). See [Access Control](https://www.rabbitmq.com/access-control.html) for the full RabbitMQ authorization model.
 
 ```yaml
 apiVersion: engine.kubevault.com/v1alpha1


### PR DESCRIPTION
User-facing guide for the OpenBao [`rabbitmq-database-plugin`](https://github.com/sigilr/openbao/pull/8) secret engine: AppBinding → SecretEngine → RabbitMQRole → SecretAccessRequest flow, plugin-specific caveats, and example payloads.

Companion PRs:
- apimachinery (CRDs): kubevault/apimachinery
- operator (reconciler): kubevault/operator

## Test plan
- [ ] Render docs locally and click through the new page