### PR TITLE
Document the hub-spoke (VaultAgent) deployment model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,9 @@ jobs:
           helm install stash-crds appscode/stash-crds
           # register kubestash crds
           kubectl create -f https://github.com/kubestash/installer/raw/master/crds/kubestash-crds.yaml
+          # register ocm crds
+          kubectl create -f https://github.com/open-cluster-management-io/api/raw/main/cluster/v1beta2/0000_01_clusters.open-cluster-management.io_managedclustersetbindings.crd.yaml
+          kubectl create -f https://github.com/open-cluster-management-io/api/raw/main/cluster/v1beta1/0000_02_clusters.open-cluster-management.io_placements.crd.yaml
 
       - name: Check codespan schema
         run: |

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -53,6 +53,12 @@ A `VaultServer` is a `Kubernetes CustomResourceDefinition (CRD)` which is used t
 
 - [VaultServer](/docs/concepts/vault-server-crds/vaultserver.md)
 
+## Vault Agent
+
+A `VaultAgent` is a `Kubernetes CustomResourceDefinition (CRD)` which deploys an OpenBao spoke agent that connects a spoke cluster to a central hub `VaultServer`, enabling credential management for databases that are only reachable from the spoke cluster.
+
+- [VaultAgent](/docs/concepts/vault-server-crds/vaultagent.md)
+
 ### Vault Unsealer Options
 When a `Vault` server is started, it starts in a `sealed` state. In this state, Vault is configured to know where and how to access the physical storage, but doesn't know how to decrypt any of it.
 

--- a/docs/concepts/vault-server-crds/appbinding.md
+++ b/docs/concepts/vault-server-crds/appbinding.md
@@ -183,7 +183,8 @@ The plugin mapping when `deploymentMode` is `RemoteAgent`:
 | postgres | `remote-postgres-plugin` |
 | mysql, mariadb | `remote-mysql-plugin` |
 | redis | `remote-redis-plugin` |
-| mongodb, elasticsearch | not supported through the spoke agent; SecretEngine reconcile fails with an error |
+| valkey | `remote-valkey-plugin` |
+| mongodb, elasticsearch | not supported through the spoke agent; the SecretEngine is rejected on apply by the validating webhook (and again at config-write) |
 
 Note: the `vault-type: remote` AppBinding label is a list-filter convenience only. Routing decisions always come from `spec.parameters.deploymentMode`.
 

--- a/docs/concepts/vault-server-crds/appbinding.md
+++ b/docs/concepts/vault-server-crds/appbinding.md
@@ -160,6 +160,37 @@ unsealer:
   secretThreshold: 3
 ```
 
+### spec.parameters.deploymentMode
+
+`spec.parameters.deploymentMode` indicates how this AppBinding reaches the Vault server. It is an enum with two values:
+
+- `Local` (the default when absent): the Vault server is reachable in-cluster (or directly). Database secret engines configured through this AppBinding use the built-in `<db>-database-plugin` family.
+- `RemoteAgent`: this AppBinding was authored for a spoke cluster that reaches a hub Vault through the OpenBao spoke agent (see the [VaultAgent concept](/docs/concepts/vault-server-crds/vaultagent.md)). Database secret engines configured through this AppBinding use the hub-side `remote-<db>-plugin` proxy family, which brokers plugin calls to the spoke agent over mTLS gRPC.
+
+```yaml
+spec:
+  parameters:
+    apiVersion: config.kubevault.com/v1alpha1
+    kind: VaultServerConfiguration
+    deploymentMode: RemoteAgent
+    spokeName: cluster-1
+```
+
+The plugin mapping when `deploymentMode` is `RemoteAgent`:
+
+| engine | plugin |
+|---|---|
+| postgres | `remote-postgres-plugin` |
+| mysql, mariadb | `remote-mysql-plugin` |
+| redis | `remote-redis-plugin` |
+| mongodb, elasticsearch | not supported through the spoke agent; SecretEngine reconcile fails with an error |
+
+Note: the `vault-type: remote` AppBinding label is a list-filter convenience only. Routing decisions always come from `spec.parameters.deploymentMode`.
+
+### spec.parameters.spokeName
+
+`spec.parameters.spokeName` is the spoke cluster identity registered with the hub's agent backend. It is required when `deploymentMode` is `RemoteAgent` and is written into database mount configurations as `spoke_name`, telling the hub which connected spoke runs the actual database plugin.
+
 ### spec.clientConfig
 
 `spec.clientConfig` is a required field that specifies the information to make a connection with an app.

--- a/docs/concepts/vault-server-crds/vaultagent.md
+++ b/docs/concepts/vault-server-crds/vaultagent.md
@@ -136,7 +136,10 @@ Both `caSecret` and `certSecret` are required in this mode — the spoke-CA is n
 
 `spec.reconnect` controls whether the agent reconnects to the hub after the stream drops (defaults: enabled).
 
-`bao agent run` has no internal reconnect loop — it exits when the hub stream drops and relies on the Pod to bring it back. The operator therefore maps `reconnect.enabled` onto the Pod's `restartPolicy`: `Always` when enabled (the kubelet relaunches the agent, which re-dials the hub) and `OnFailure` when disabled (a clean hub disconnect leaves the agent down; genuine crashes still recover).
+`bao agent run` has no internal reconnect loop — it exits when the hub stream drops and relies on the Pod to bring it back. The operator therefore maps `reconnect.enabled` onto the Pod's `restartPolicy`:
+
+- **enabled** (default): `restartPolicy: Always` — the kubelet relaunches the agent, which re-dials the hub.
+- **disabled**: `restartPolicy: OnFailure` — a clean hub disconnect leaves the agent stopped (the operator also leaves the completed Pod in place rather than recreating it, and reports `status.phase: Disconnected`); genuine crashes still recover in place.
 
 > **Note:** `backoffSeconds` and `maxBackoffSeconds` are not honored — restart timing is governed by the kubelet's CrashLoopBackoff and cannot be tuned through these fields.
 

--- a/docs/concepts/vault-server-crds/vaultagent.md
+++ b/docs/concepts/vault-server-crds/vaultagent.md
@@ -164,7 +164,7 @@ status:
 - `podName`: name of the spoke-agent Pod.
 - `appBindingRef`: references the AppBinding for the hub Vault (delivered by the hub `ManifestWork` in hub-managed deployments). Spoke-side consumers (SecretEngine, database role CRDs, KubeDB) use this AppBinding.
 - `lastHeartbeat`: timestamp of the last successful heartbeat to the hub, if reported by the agent.
-- `certExpiry`: expiry of the current spoke client certificate, if known.
+- `certExpiry`: expiry of the spoke client certificate. The operator sets this for **pre-provisioned (`spec.tls`) agents** by reading `certSecret` directly. For **bootstrap agents** the certificate lives only in the pod, so the operator does not set it here — the hub reports it instead on the VaultServer's `status.agentPlacement.clusters[].certExpiry` (sourced from the agent backend's `agent/spokes` endpoint).
 - `conditions`: the latest available observations of the VaultAgent's state.
 
 In hub-managed deployments, `status.phase` is scraped back to the hub through `ManifestWork` status feedback and aggregated into the hub VaultServer's `status.agentPlacement`.

--- a/docs/concepts/vault-server-crds/vaultagent.md
+++ b/docs/concepts/vault-server-crds/vaultagent.md
@@ -26,9 +26,9 @@ This is the spoke half of the KubeVault hub-spoke model:
 A `VaultAgent` can be created two ways:
 
 1. **Hub-managed (recommended)**: set `spec.agentPlacementRef` on the hub `VaultServer`. The KubeVault operator resolves the referenced OCM `Placement` and delivers a fully wired `VaultAgent` (plus its AppBinding and credentials) to every selected managed cluster via `ManifestWork`. See the [hub-spoke deployment guide](/docs/guides/hub-spoke/deploy-hub-spoke.md).
-2. **Standalone**: create the `VaultAgent` by hand in the spoke cluster, supplying the join material yourself.
+2. **Standalone**: create the `VaultAgent` by hand in the spoke cluster. You must set `spec.bootstrap` and supply the join Secret it references yourself (see [spec.bootstrap](#specbootstrap)).
 
-When a `VaultAgent` is created, the KubeVault operator in the spoke cluster provisions a ServiceAccount, the spoke-agent Pod, and an AppBinding pointing back at the hub VaultServer (unless a hub-authored AppBinding already exists).
+`spec.bootstrap` is required: the spoke agent obtains its mTLS credentials by running `bao agent join`. When a `VaultAgent` is reconciled, the KubeVault operator in the spoke cluster provisions a ServiceAccount and the spoke-agent Pod. The AppBinding pointing back at the hub VaultServer is **not** authored by this reconciler — in hub-managed deployments it is delivered and owned by the hub's `ManifestWork`.
 
 ## VaultAgent CRD Specification
 
@@ -90,11 +90,11 @@ spec:
 - `name`, `namespace`: identify the `VaultServer` object on the hub cluster.
 - `address`: the externally reachable hub Vault API URL. In hub-managed deployments this is the hub's LoadBalancer address.
 - `grpcPort`: the port of the hub's spoke-agent gRPC proxy. Defaults to `50053`.
-- `caBundle`: optional PEM bundle used to verify TLS on the hub Vault API endpoint. Takes precedence over the `caBundle` key of `spec.bootstrap.joinSecretRef`.
+- `caBundle`: optional PEM bundle used to verify TLS on the hub Vault API endpoint. When set, the `bao agent join` init container is told to verify the hub against the CA delivered in the `caBundle` key of `spec.bootstrap.joinSecretRef`.
 
 #### spec.bootstrap
 
-`spec.bootstrap` is an optional field that configures the automated `bao agent join` trust bootstrap. When set, the spoke-agent Pod runs a join init container that exchanges a hub-issued bootstrap token for mTLS client credentials before the long-running agent starts. Credentials live on an emptyDir; the agent renews its own certificate in place, and a Pod restart simply re-joins with the current token.
+`spec.bootstrap` configures the automated `bao agent join` trust bootstrap. The spoke-agent Pod runs a join init container that exchanges a hub-issued bootstrap token for mTLS client credentials before the long-running agent starts. Credentials live on an emptyDir; the agent renews its own certificate in place, and a Pod restart simply re-joins with the current token.
 
 ```yaml
 spec:
@@ -113,26 +113,32 @@ The referenced Secret must carry:
 
 In hub-managed deployments the operator creates and rotates this Secret automatically (tokens default to a 24h TTL and are rotated when less than a quarter of the TTL remains).
 
-Exactly one of `spec.bootstrap` or `spec.tls.certSecret` (pre-provisioned credentials) should be used.
-
-#### spec.tokenSecretRef
-
-`spec.tokenSecretRef` is an optional field referencing a Secret with a `token` key holding a Vault token. When set, the AppBinding created for this agent authenticates to the hub Vault with that token instead of kubernetes auth.
+> **Note:** `spec.bootstrap` is currently required. The operator rejects a `VaultAgent` that does not set it, because the spoke agent has no other supported way to obtain its mTLS credentials.
 
 #### spec.image
 
 `spec.image` is an optional field that overrides the spoke-agent container image.
 
+#### spec.tokenSecretRef
+
+`spec.tokenSecretRef` is an optional field referencing a Secret with a `token` key holding a Vault token.
+
+> **Note:** Reserved for future use. The current operator does not author the spoke AppBinding (it is delivered by the hub `ManifestWork`), so this field has no effect today.
+
 #### spec.tls
 
-`spec.tls` is an optional field for pre-provisioned mTLS credentials, as an alternative to `spec.bootstrap`:
+`spec.tls` describes pre-provisioned mTLS credentials as an alternative to the `spec.bootstrap` join flow:
 
 - `caSecret`: Secret with `ca.crt` (the hub's spoke-CA certificate).
 - `certSecret`: Secret with `tls.crt` and `tls.key` (a client certificate whose CN equals `spec.spokeName`, signed by the spoke-CA).
 
+> **Note:** Not yet implemented. The current operator requires `spec.bootstrap`; pre-provisioned credentials are not consumed yet.
+
 #### spec.reconnect
 
-`spec.reconnect` is an optional field controlling automatic reconnection to the hub. Defaults: enabled, 5s initial backoff, 300s max backoff.
+`spec.reconnect` describes automatic reconnection to the hub (defaults: enabled, 5s initial backoff, 300s max backoff).
+
+> **Note:** Reserved. These fields are not yet wired into the spoke-agent Pod; reconnection is handled by the agent's own defaults.
 
 #### spec.podTemplate
 
@@ -151,10 +157,10 @@ status:
   certExpiry: "2026-07-12T10:00:00Z"
 ```
 
-- `phase`: one of `Pending`, `Connected`, `Disconnected`, `Error`.
+- `phase`: one of `Pending`, `Connected`, `Disconnected`, `Error`. The operator derives this from the spoke-agent Pod's readiness — `Connected` only once the Pod is Running and Ready.
 - `podName`: name of the spoke-agent Pod.
-- `appBindingRef`: the AppBinding created for the hub Vault. Spoke-side consumers (SecretEngine, database role CRDs, KubeDB) use this AppBinding.
-- `lastHeartbeat`: timestamp of the last successful heartbeat to the hub.
+- `appBindingRef`: references the AppBinding for the hub Vault (delivered by the hub `ManifestWork` in hub-managed deployments). Spoke-side consumers (SecretEngine, database role CRDs, KubeDB) use this AppBinding.
+- `lastHeartbeat`: timestamp of the last successful heartbeat to the hub, if reported by the agent.
 - `certExpiry`: expiry of the current spoke client certificate, if known.
 - `conditions`: the latest available observations of the VaultAgent's state.
 
@@ -165,8 +171,9 @@ In hub-managed deployments, `status.phase` is scraped back to the hub through `M
 For every `VaultAgent`, the spoke-side KubeVault operator provisions:
 
 - a **ServiceAccount** for the agent Pod
-- the **spoke-agent Pod**: with `spec.bootstrap` set, an init container runs `bao agent join` (verifying the hub via the bootstrap token's JWS signature plus the SPKI pin) and writes credentials to an emptyDir; the main container runs `bao agent run -server=<hub>:<grpcPort> -credentials-dir=...`
-- an **AppBinding** for the hub VaultServer, unless a hub-authored AppBinding (label `app.kubernetes.io/managed-by: kubevault-hub`) already exists. The AppBinding parameters carry `deploymentMode: RemoteAgent` and `spokeName`, which the secret engine machinery uses to route database mounts through the hub's `remote-<db>-plugin` proxies. See the [AppBinding concept](/docs/concepts/vault-server-crds/appbinding.md).
+- the **spoke-agent Pod**: an init container runs `bao agent join` (verifying the hub via the bootstrap token's JWS signature plus the SPKI pin) and writes credentials to an emptyDir; the main container runs `bao agent run -server=<hub>:<grpcPort> -credentials-dir=...`. The Pod is replaced when its template changes (image, podTemplate, resources, or the referenced join Secret).
+
+The **AppBinding** for the hub VaultServer is **not** authored by this reconciler. In hub-managed deployments it is delivered and owned by the hub's `ManifestWork` (labeled `app.kubernetes.io/managed-by: kubevault-hub`). Its parameters carry `deploymentMode: RemoteAgent` and `spokeName`, which the secret engine machinery uses to route database mounts through the hub's `remote-<db>-plugin` proxies. See the [AppBinding concept](/docs/concepts/vault-server-crds/appbinding.md).
 
 ## Next Steps
 

--- a/docs/concepts/vault-server-crds/vaultagent.md
+++ b/docs/concepts/vault-server-crds/vaultagent.md
@@ -26,9 +26,9 @@ This is the spoke half of the KubeVault hub-spoke model:
 A `VaultAgent` can be created two ways:
 
 1. **Hub-managed (recommended)**: set `spec.agentPlacementRef` on the hub `VaultServer`. The KubeVault operator resolves the referenced OCM `Placement` and delivers a fully wired `VaultAgent` (plus its AppBinding and credentials) to every selected managed cluster via `ManifestWork`. See the [hub-spoke deployment guide](/docs/guides/hub-spoke/deploy-hub-spoke.md).
-2. **Standalone**: create the `VaultAgent` by hand in the spoke cluster. You must set `spec.bootstrap` and supply the join Secret it references yourself (see [spec.bootstrap](#specbootstrap)).
+2. **Standalone**: create the `VaultAgent` by hand in the spoke cluster, providing the credential material yourself — either a [`spec.bootstrap`](#specbootstrap) join Secret or pre-provisioned [`spec.tls`](#spectls) certificates.
 
-`spec.bootstrap` is required: the spoke agent obtains its mTLS credentials by running `bao agent join`. When a `VaultAgent` is reconciled, the KubeVault operator in the spoke cluster provisions a ServiceAccount and the spoke-agent Pod. The AppBinding pointing back at the hub VaultServer is **not** authored by this reconciler — in hub-managed deployments it is delivered and owned by the hub's `ManifestWork`.
+When a `VaultAgent` is reconciled, the KubeVault operator in the spoke cluster provisions a ServiceAccount, the spoke-agent Pod, and — for standalone agents — an AppBinding pointing back at the hub VaultServer. In hub-managed deployments the AppBinding is instead delivered and owned by the hub's `ManifestWork`, and the operator defers to that copy.
 
 ## VaultAgent CRD Specification
 
@@ -94,7 +94,7 @@ spec:
 
 #### spec.bootstrap
 
-`spec.bootstrap` configures the automated `bao agent join` trust bootstrap. The spoke-agent Pod runs a join init container that exchanges a hub-issued bootstrap token for mTLS client credentials before the long-running agent starts. Credentials live on an emptyDir; the agent renews its own certificate in place, and a Pod restart simply re-joins with the current token.
+`spec.bootstrap` configures the automated `bao agent join` trust bootstrap. When set, the spoke-agent Pod runs a join init container that exchanges a hub-issued bootstrap token for mTLS client credentials before the long-running agent starts. Credentials live on an emptyDir; the agent renews its own certificate in place, and a Pod restart simply re-joins with the current token.
 
 ```yaml
 spec:
@@ -113,7 +113,7 @@ The referenced Secret must carry:
 
 In hub-managed deployments the operator creates and rotates this Secret automatically (tokens default to a 24h TTL and are rotated when less than a quarter of the TTL remains).
 
-> **Note:** `spec.bootstrap` is currently required. The operator rejects a `VaultAgent` that does not set it, because the spoke agent has no other supported way to obtain its mTLS credentials.
+> **Note:** Set exactly one credential source — `spec.bootstrap` (this join flow) or [`spec.tls`](#spectls) (pre-provisioned certificates). The operator rejects a `VaultAgent` that sets neither or both.
 
 #### spec.image
 
@@ -121,24 +121,20 @@ In hub-managed deployments the operator creates and rotates this Secret automati
 
 #### spec.tokenSecretRef
 
-`spec.tokenSecretRef` is an optional field referencing a Secret with a `token` key holding a Vault token.
-
-> **Note:** Reserved for future use. The current operator does not author the spoke AppBinding (it is delivered by the hub `ManifestWork`), so this field has no effect today.
+`spec.tokenSecretRef` is an optional field referencing a Secret with a `token` key holding a Vault token. For standalone agents — where the operator authors the AppBinding — that AppBinding authenticates to the hub Vault with this token instead of the agent's ServiceAccount. It has no effect in hub-managed deployments, where the AppBinding is delivered by the hub `ManifestWork`.
 
 #### spec.tls
 
-`spec.tls` describes pre-provisioned mTLS credentials as an alternative to the `spec.bootstrap` join flow:
+`spec.tls` provides pre-provisioned mTLS credentials as an alternative to the `spec.bootstrap` join flow. When set (and `spec.bootstrap` is not), the spoke-agent Pod skips `bao agent join` and runs `bao agent run` directly against these credentials:
 
 - `caSecret`: Secret with `ca.crt` (the hub's spoke-CA certificate).
 - `certSecret`: Secret with `tls.crt` and `tls.key` (a client certificate whose CN equals `spec.spokeName`, signed by the spoke-CA).
 
-> **Note:** Not yet implemented. The current operator requires `spec.bootstrap`; pre-provisioned credentials are not consumed yet.
+The operator projects these into the agent's credentials directory as `cert.pem`/`key.pem`/`ca.pem` (read-only) and disables in-agent certificate renewal (`-renew-check-every=0`). You rotate the certificate Secrets out-of-band; changing them rolls the Pod.
 
 #### spec.reconnect
 
-`spec.reconnect` describes automatic reconnection to the hub (defaults: enabled, 5s initial backoff, 300s max backoff).
-
-> **Note:** Reserved. These fields are not yet wired into the spoke-agent Pod; reconnection is handled by the agent's own defaults.
+`spec.reconnect` configures automatic reconnection to the hub (defaults: enabled, 5s initial backoff, 300s max backoff). The operator surfaces these to the agent container as `BAO_AGENT_RECONNECT_ENABLED`, `BAO_AGENT_RECONNECT_BACKOFF_SECONDS`, and `BAO_AGENT_RECONNECT_MAX_BACKOFF_SECONDS` environment variables (the `bao agent run` command has no equivalent CLI flags).
 
 #### spec.podTemplate
 
@@ -171,9 +167,8 @@ In hub-managed deployments, `status.phase` is scraped back to the hub through `M
 For every `VaultAgent`, the spoke-side KubeVault operator provisions:
 
 - a **ServiceAccount** for the agent Pod
-- the **spoke-agent Pod**: an init container runs `bao agent join` (verifying the hub via the bootstrap token's JWS signature plus the SPKI pin) and writes credentials to an emptyDir; the main container runs `bao agent run -server=<hub>:<grpcPort> -credentials-dir=...`. The Pod is replaced when its template changes (image, podTemplate, resources, or the referenced join Secret).
-
-The **AppBinding** for the hub VaultServer is **not** authored by this reconciler. In hub-managed deployments it is delivered and owned by the hub's `ManifestWork` (labeled `app.kubernetes.io/managed-by: kubevault-hub`). Its parameters carry `deploymentMode: RemoteAgent` and `spokeName`, which the secret engine machinery uses to route database mounts through the hub's `remote-<db>-plugin` proxies. See the [AppBinding concept](/docs/concepts/vault-server-crds/appbinding.md).
+- the **spoke-agent Pod**: with `spec.bootstrap`, an init container runs `bao agent join` (verifying the hub via the bootstrap token's JWS signature plus the SPKI pin) and writes credentials to an emptyDir; with `spec.tls`, the pre-provisioned certificates are projected read-only and there is no init container. The main container runs `bao agent run -server=<hub>:<grpcPort> -credentials-dir=...`. The Pod is replaced when its template changes (image, podTemplate, resources, or the referenced Secrets).
+- an **AppBinding** for the hub VaultServer (standalone agents only). Its parameters carry `deploymentMode: RemoteAgent` and `spokeName`, which the secret engine machinery uses to route database mounts through the hub's `remote-<db>-plugin` proxies. In hub-managed deployments this AppBinding is instead delivered and owned by the hub's `ManifestWork` (labeled `app.kubernetes.io/managed-by: kubevault-hub`), and the operator defers to that copy. See the [AppBinding concept](/docs/concepts/vault-server-crds/appbinding.md).
 
 ## Next Steps
 

--- a/docs/concepts/vault-server-crds/vaultagent.md
+++ b/docs/concepts/vault-server-crds/vaultagent.md
@@ -130,11 +130,15 @@ In hub-managed deployments the operator creates and rotates this Secret automati
 - `caSecret`: Secret with `ca.crt` (the hub's spoke-CA certificate).
 - `certSecret`: Secret with `tls.crt` and `tls.key` (a client certificate whose CN equals `spec.spokeName`, signed by the spoke-CA).
 
-The operator projects these into the agent's credentials directory as `cert.pem`/`key.pem`/`ca.pem` (read-only) and disables in-agent certificate renewal (`-renew-check-every=0`). You rotate the certificate Secrets out-of-band; changing them rolls the Pod.
+Both `caSecret` and `certSecret` are required in this mode — the spoke-CA is needed to verify the hub's server certificate. The operator projects them into the agent's credentials directory as `cert.pem`/`key.pem`/`ca.pem` (read-only) and disables in-agent certificate renewal (`-renew-check-every=0`). You rotate the certificate Secrets out-of-band. Note the Pod template references the Secrets by name: changing a Secret *reference* rolls the Pod, but rotating a Secret's contents in place does **not** — restart the agent Pod for it to pick up the new credentials.
 
 #### spec.reconnect
 
-`spec.reconnect` configures automatic reconnection to the hub (defaults: enabled, 5s initial backoff, 300s max backoff). The operator surfaces these to the agent container as `BAO_AGENT_RECONNECT_ENABLED`, `BAO_AGENT_RECONNECT_BACKOFF_SECONDS`, and `BAO_AGENT_RECONNECT_MAX_BACKOFF_SECONDS` environment variables (the `bao agent run` command has no equivalent CLI flags).
+`spec.reconnect` controls whether the agent reconnects to the hub after the stream drops (defaults: enabled).
+
+`bao agent run` has no internal reconnect loop — it exits when the hub stream drops and relies on the Pod to bring it back. The operator therefore maps `reconnect.enabled` onto the Pod's `restartPolicy`: `Always` when enabled (the kubelet relaunches the agent, which re-dials the hub) and `OnFailure` when disabled (a clean hub disconnect leaves the agent down; genuine crashes still recover).
+
+> **Note:** `backoffSeconds` and `maxBackoffSeconds` are not honored — restart timing is governed by the kubelet's CrashLoopBackoff and cannot be tuned through these fields.
 
 #### spec.podTemplate
 

--- a/docs/concepts/vault-server-crds/vaultagent.md
+++ b/docs/concepts/vault-server-crds/vaultagent.md
@@ -1,0 +1,174 @@
+---
+title: Vault Agent | KubeVault Concepts
+menu:
+  docs_{{ .version }}:
+    identifier: vaultagent-vault-server-crds
+    name: Vault Agent
+    parent: vault-server-crds-concepts
+    weight: 12
+menu_name: docs_{{ .version }}
+section_menu_id: concepts
+---
+
+> New to KubeVault? Please start [here](/docs/concepts/README.md).
+
+# VaultAgent
+
+## What is VaultAgent
+
+A `VaultAgent` is a Kubernetes `CustomResourceDefinition` (CRD) which deploys an OpenBao spoke agent (`bao agent run`) in a Kubernetes cluster. The spoke agent connects to a central hub `VaultServer` over mTLS gRPC and runs database secret engine plugins in-process, next to databases that are only reachable from the spoke cluster.
+
+This is the spoke half of the KubeVault hub-spoke model:
+
+- The **hub** cluster runs a `VaultServer`. Its `agent/` backend issues spoke client certificates and brokers database plugin calls to connected spokes through `remote-<db>-plugin` proxy plugins.
+- Each **spoke** cluster runs a `VaultAgent`. Databases in the spoke cluster never need to be reachable from the hub; credential operations travel over the agent's outbound mTLS connection.
+
+A `VaultAgent` can be created two ways:
+
+1. **Hub-managed (recommended)**: set `spec.agentPlacementRef` on the hub `VaultServer`. The KubeVault operator resolves the referenced OCM `Placement` and delivers a fully wired `VaultAgent` (plus its AppBinding and credentials) to every selected managed cluster via `ManifestWork`. See the [hub-spoke deployment guide](/docs/guides/hub-spoke/deploy-hub-spoke.md).
+2. **Standalone**: create the `VaultAgent` by hand in the spoke cluster, supplying the join material yourself.
+
+When a `VaultAgent` is created, the KubeVault operator in the spoke cluster provisions a ServiceAccount, the spoke-agent Pod, and an AppBinding pointing back at the hub VaultServer (unless a hub-authored AppBinding already exists).
+
+## VaultAgent CRD Specification
+
+Like any official Kubernetes resource, a `VaultAgent` object has `TypeMeta`, `ObjectMeta`, `Spec` and `Status` sections.
+
+A sample `VaultAgent` object is shown below:
+
+```yaml
+apiVersion: kubevault.com/v1alpha2
+kind: VaultAgent
+metadata:
+  name: vault-agent
+  namespace: demo
+spec:
+  spokeName: cluster-1
+  hubVaultRef:
+    name: vault
+    namespace: demo
+    address: https://bao.example.com:8200
+    grpcPort: 50053
+    caBundle: <base64 PEM bundle>
+  bootstrap:
+    joinSecretRef:
+      name: vault-agent-join
+  image: ghcr.io/kubevault/spoke-agent:v0.1.0
+  reconnect:
+    enabled: true
+    backoffSeconds: 5
+    maxBackoffSeconds: 300
+```
+
+Here, we are going to describe the various sections of the `VaultAgent` crd.
+
+### VaultAgent Spec
+
+#### spec.spokeName
+
+`spec.spokeName` is a required field that specifies the unique identity of this spoke cluster. The hub pins issued client certificates and bootstrap tokens to this name, and database mounts on the hub reference it as `spoke_name`. In hub-managed deployments this is the OCM `ManagedCluster` name.
+
+```yaml
+spec:
+  spokeName: cluster-1
+```
+
+#### spec.hubVaultRef
+
+`spec.hubVaultRef` is a required field that specifies how to reach the hub VaultServer.
+
+```yaml
+spec:
+  hubVaultRef:
+    name: vault                            # VaultServer name on the hub
+    namespace: demo                        # VaultServer namespace on the hub
+    address: https://bao.example.com:8200  # hub Vault API URL (LoadBalancer address)
+    grpcPort: 50053                        # hub gRPC proxy port (default 50053)
+    caBundle: <base64 PEM>                 # CA bundle to verify the hub Vault API endpoint
+```
+
+- `name`, `namespace`: identify the `VaultServer` object on the hub cluster.
+- `address`: the externally reachable hub Vault API URL. In hub-managed deployments this is the hub's LoadBalancer address.
+- `grpcPort`: the port of the hub's spoke-agent gRPC proxy. Defaults to `50053`.
+- `caBundle`: optional PEM bundle used to verify TLS on the hub Vault API endpoint. Takes precedence over the `caBundle` key of `spec.bootstrap.joinSecretRef`.
+
+#### spec.bootstrap
+
+`spec.bootstrap` is an optional field that configures the automated `bao agent join` trust bootstrap. When set, the spoke-agent Pod runs a join init container that exchanges a hub-issued bootstrap token for mTLS client credentials before the long-running agent starts. Credentials live on an emptyDir; the agent renews its own certificate in place, and a Pod restart simply re-joins with the current token.
+
+```yaml
+spec:
+  bootstrap:
+    joinSecretRef:
+      name: vault-agent-join
+```
+
+The referenced Secret must carry:
+
+| key | value |
+|---|---|
+| `token` | hub bootstrap token (`<id>.<secret>`), minted by the hub's `agent/bootstrap-tokens` endpoint |
+| `hubCertHash` | `sha256:<hex>` SPKI pin of the hub's spoke-CA |
+| `caBundle` | optional PEM CA bundle for the hub Vault API endpoint |
+
+In hub-managed deployments the operator creates and rotates this Secret automatically (tokens default to a 24h TTL and are rotated when less than a quarter of the TTL remains).
+
+Exactly one of `spec.bootstrap` or `spec.tls.certSecret` (pre-provisioned credentials) should be used.
+
+#### spec.tokenSecretRef
+
+`spec.tokenSecretRef` is an optional field referencing a Secret with a `token` key holding a Vault token. When set, the AppBinding created for this agent authenticates to the hub Vault with that token instead of kubernetes auth.
+
+#### spec.image
+
+`spec.image` is an optional field that overrides the spoke-agent container image.
+
+#### spec.tls
+
+`spec.tls` is an optional field for pre-provisioned mTLS credentials, as an alternative to `spec.bootstrap`:
+
+- `caSecret`: Secret with `ca.crt` (the hub's spoke-CA certificate).
+- `certSecret`: Secret with `tls.crt` and `tls.key` (a client certificate whose CN equals `spec.spokeName`, signed by the spoke-CA).
+
+#### spec.reconnect
+
+`spec.reconnect` is an optional field controlling automatic reconnection to the hub. Defaults: enabled, 5s initial backoff, 300s max backoff.
+
+#### spec.podTemplate
+
+`spec.podTemplate` is an optional configuration (resources, nodeSelector, etc) for the spoke-agent Pod.
+
+### VaultAgent Status
+
+```yaml
+status:
+  phase: Connected
+  podName: vault-agent-agent
+  appBindingRef:
+    name: vault-agent-hub-vault
+    namespace: demo
+  lastHeartbeat: "2026-06-12T10:00:00Z"
+  certExpiry: "2026-07-12T10:00:00Z"
+```
+
+- `phase`: one of `Pending`, `Connected`, `Disconnected`, `Error`.
+- `podName`: name of the spoke-agent Pod.
+- `appBindingRef`: the AppBinding created for the hub Vault. Spoke-side consumers (SecretEngine, database role CRDs, KubeDB) use this AppBinding.
+- `lastHeartbeat`: timestamp of the last successful heartbeat to the hub.
+- `certExpiry`: expiry of the current spoke client certificate, if known.
+- `conditions`: the latest available observations of the VaultAgent's state.
+
+In hub-managed deployments, `status.phase` is scraped back to the hub through `ManifestWork` status feedback and aggregated into the hub VaultServer's `status.agentPlacement`.
+
+## What the operator creates
+
+For every `VaultAgent`, the spoke-side KubeVault operator provisions:
+
+- a **ServiceAccount** for the agent Pod
+- the **spoke-agent Pod**: with `spec.bootstrap` set, an init container runs `bao agent join` (verifying the hub via the bootstrap token's JWS signature plus the SPKI pin) and writes credentials to an emptyDir; the main container runs `bao agent run -server=<hub>:<grpcPort> -credentials-dir=...`
+- an **AppBinding** for the hub VaultServer, unless a hub-authored AppBinding (label `app.kubernetes.io/managed-by: kubevault-hub`) already exists. The AppBinding parameters carry `deploymentMode: RemoteAgent` and `spokeName`, which the secret engine machinery uses to route database mounts through the hub's `remote-<db>-plugin` proxies. See the [AppBinding concept](/docs/concepts/vault-server-crds/appbinding.md).
+
+## Next Steps
+
+- Deploy the full hub-spoke model with OCM: [guide](/docs/guides/hub-spoke/deploy-hub-spoke.md).
+- Learn about the [VaultServer](/docs/concepts/vault-server-crds/vaultserver.md) CRD and its `spec.agentPlacementRef` field.

--- a/docs/concepts/vault-server-crds/vaultserver.md
+++ b/docs/concepts/vault-server-crds/vaultserver.md
@@ -397,7 +397,7 @@ status:
 
   - `ready`: The number of clusters whose VaultAgent reports phase `Connected`.
 
-  - `clusters`: Per-cluster detail, each entry carrying `clusterName`, `phase` (the spoke VaultAgent phase, or hub-side values `WorkApplied`, `WorkProgressing`, `WorkDegraded`), and `tokenExpiry` (when the current bootstrap token for that spoke expires).
+  - `clusters`: Per-cluster detail, each entry carrying `clusterName`, `phase` (the spoke VaultAgent phase, or hub-side values `WorkApplied`, `WorkProgressing`, `WorkDegraded`), `tokenExpiry` (when the current bootstrap token for that spoke expires), and `certExpiry` (when the spoke's mTLS client certificate expires, as observed by the hub's `agent/spokes` endpoint; absent until the spoke connects).
 
   ```yaml
   status:
@@ -410,9 +410,11 @@ status:
         - clusterName: cluster-1
           phase: Connected
           tokenExpiry: "2026-06-13T10:00:00Z"
+          certExpiry: "2026-07-12T10:00:00Z"
         - clusterName: cluster-2
           phase: Connected
           tokenExpiry: "2026-06-13T10:00:00Z"
+          certExpiry: "2026-07-12T10:00:00Z"
   ```
 
 - Hub-spoke deployments add the following condition types to `status.conditions`:

--- a/docs/concepts/vault-server-crds/vaultserver.md
+++ b/docs/concepts/vault-server-crds/vaultserver.md
@@ -342,8 +342,8 @@ spec:
 Requirements:
 
 - The OCM hub CRDs (`Placement`, `PlacementDecision`, `ManifestWork`) must be installed; the field is ignored with a warning condition otherwise.
-- The `vault` service template must be `type: LoadBalancer` so spoke clusters can reach the Vault API (port 8200) and the spoke-agent gRPC proxy (port 50053).
-- `spec.tls` must be enabled, since spokes connect over the external LoadBalancer address.
+- Spoke clusters must be able to reach the hub Vault API (port 8200) and the spoke-agent gRPC proxy (port 50053) at an externally-resolvable address. By default the `vault` service template must be `type: LoadBalancer`; alternatively, set the `kubevault.com/agent-hub-address` annotation on the VaultServer to an external address (NodePort + external LB, Gateway, …) and the LoadBalancer requirement is waived.
+- `spec.tls` must be enabled, since spokes connect over that external address.
 
 For each selected cluster the operator creates a ServiceAccount (in the managed cluster's namespace on the hub) whose token the spoke uses for kubernetes auth, a `VaultPolicy` and `VaultPolicyBinding` granting that ServiceAccount the permissions a spoke needs, a rotated bootstrap token for the `bao agent join` trust bootstrap, and a `ManifestWork` carrying the `VaultAgent`, its AppBinding, and the credential Secrets. See the [hub-spoke deployment guide](/docs/guides/hub-spoke/deploy-hub-spoke.md).
 

--- a/docs/concepts/vault-server-crds/vaultserver.md
+++ b/docs/concepts/vault-server-crds/vaultserver.md
@@ -329,6 +329,37 @@ spec:
 
 - `passthroughRequestHeaders`: `Optional`. Specifies a list of headers to whitelist and pass from the request to the backend.
 
+#### spec.agentPlacementRef
+
+`spec.agentPlacementRef` is an optional field that points to an [Open Cluster Management](https://open-cluster-management.io/) `Placement` object in the same namespace as the `VaultServer`. When set, the KubeVault operator deploys a [VaultAgent](/docs/concepts/vault-server-crds/vaultagent.md) to every managed cluster selected by the Placement, using one `ManifestWork` per cluster. This turns the VaultServer into the hub of a hub-spoke deployment: databases in the selected spoke clusters can be managed through this Vault without being reachable from the hub.
+
+```yaml
+spec:
+  agentPlacementRef:
+    name: db-spokes
+```
+
+Requirements:
+
+- The OCM hub CRDs (`Placement`, `PlacementDecision`, `ManifestWork`) must be installed; the field is ignored with a warning condition otherwise.
+- The `vault` service template must be `type: LoadBalancer` so spoke clusters can reach the Vault API (port 8200) and the spoke-agent gRPC proxy (port 50053).
+- `spec.tls` must be enabled, since spokes connect over the external LoadBalancer address.
+
+For each selected cluster the operator creates a ServiceAccount (in the managed cluster's namespace on the hub) whose token the spoke uses for kubernetes auth, a `VaultPolicy` and `VaultPolicyBinding` granting that ServiceAccount the permissions a spoke needs, a rotated bootstrap token for the `bao agent join` trust bootstrap, and a `ManifestWork` carrying the `VaultAgent`, its AppBinding, and the credential Secrets. See the [hub-spoke deployment guide](/docs/guides/hub-spoke/deploy-hub-spoke.md).
+
+#### spec.agentTemplate
+
+`spec.agentTemplate` is an optional field that customizes the VaultAgents stamped out for clusters selected by `spec.agentPlacementRef`. Per-cluster fields (`spokeName`, `hubVaultRef`, join material) are filled in by the operator.
+
+```yaml
+spec:
+  agentTemplate:
+    namespace: demo                                  # namespace on the managed cluster (defaults to the VaultServer's namespace)
+    image: ghcr.io/kubevault/spoke-agent:v0.1.0      # spoke-agent container image
+    bootstrapTokenTTL: 24h                           # TTL and rotation period of bootstrap tokens (default 24h, minimum 1h)
+    podTemplate: {}                                  # pod template for the spoke-agent pods
+```
+
 ### VaultServer Status
 
 VaultServer Status shows the status of a Vault deployment. The status of the Vault is monitored and updated by the KubeVault operator.
@@ -355,3 +386,41 @@ status:
   - `status`: Specifies whether the auth method is enabled or not.
 
   - `reason`: Specifies the reason why failed to enable the auth method.
+
+- `agentPlacement` : Summarizes spoke agent rollout when `spec.agentPlacementRef` is set. It has the following fields:
+
+  - `placement`: The resolved Placement name.
+
+  - `selected`: The number of clusters currently listed in the PlacementDecisions.
+
+  - `applied`: The number of clusters whose ManifestWork has been applied.
+
+  - `ready`: The number of clusters whose VaultAgent reports phase `Connected`.
+
+  - `clusters`: Per-cluster detail, each entry carrying `clusterName`, `phase` (the spoke VaultAgent phase, or hub-side values `WorkApplied`, `WorkProgressing`, `WorkDegraded`), and `tokenExpiry` (when the current bootstrap token for that spoke expires).
+
+  ```yaml
+  status:
+    agentPlacement:
+      placement: db-spokes
+      selected: 2
+      applied: 2
+      ready: 2
+      clusters:
+        - clusterName: cluster-1
+          phase: Connected
+          tokenExpiry: "2026-06-13T10:00:00Z"
+        - clusterName: cluster-2
+          phase: Connected
+          tokenExpiry: "2026-06-13T10:00:00Z"
+  ```
+
+- Hub-spoke deployments add the following condition types to `status.conditions`:
+
+  - `AgentPlacementResolved`: the Placement exists and its PlacementDecisions were read.
+
+  - `AgentHubInitialized`: the `agent/` backend is mounted, the spoke-CA is initialized, and the advertised endpoint matches the LoadBalancer address.
+
+  - `AgentManifestWorksApplied`: every selected cluster has an applied ManifestWork.
+
+  - `AgentsReady`: every selected cluster's VaultAgent reports `Connected`.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -36,6 +36,7 @@ Guides show you how to perform tasks with KubeVault operator and Vault CSI drive
 - To set up monitoring see [here](/docs/guides/monitoring/overview.md).
 - To use KubeVault operator for external Vault see [here](/docs/guides/platforms/external-vault.md).
 - To use KubeVault operator in multiple cluster for same Vault see [here](/docs/guides/platforms/multi-cluster-vault.md).
+- To deploy Vault in a hub-spoke model across OCM managed clusters see [here](/docs/guides/hub-spoke/deploy-hub-spoke.md).
 
 ## Using Vault CSI driver
 

--- a/docs/guides/hub-spoke/_index.md
+++ b/docs/guides/hub-spoke/_index.md
@@ -1,0 +1,10 @@
+---
+title: Hub-Spoke Deployment | KubeVault
+menu:
+  docs_{{ .version }}:
+    identifier: hub-spoke-guides
+    name: Hub-Spoke Deployment
+    parent: guides
+    weight: 15
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/hub-spoke/deploy-hub-spoke.md
+++ b/docs/guides/hub-spoke/deploy-hub-spoke.md
@@ -159,7 +159,8 @@ $ kubectl get vaultserver vault -n demo -o jsonpath='{.status.agentPlacement}' |
     {
       "clusterName": "cluster-1",
       "phase": "Connected",
-      "tokenExpiry": "2026-06-13T10:00:00Z"
+      "tokenExpiry": "2026-06-13T10:00:00Z",
+      "certExpiry": "2026-07-12T10:00:00Z"
     }
   ]
 }
@@ -179,8 +180,8 @@ And confirm the spoke is connected from inside a Vault pod:
 
 ```bash
 $ kubectl exec -n demo vault-0 -c vault -- bao agent list
-NAME       LAST SEEN  UPTIME  HEALTH
-cluster-1  1s ago     2m      OK
+NAME       LAST SEEN  UPTIME  CERT EXP  HEALTH
+cluster-1  1s ago     2m      29d       OK
 ```
 
 ## Step 4: Verify the spoke side
@@ -246,7 +247,7 @@ Request credentials the usual way with a `SecretAccessRequest`; see the [secret 
 
 - **Adding or removing spokes**: label or relabel managed clusters; the Placement decision changes and the operator converges. Removed clusters get their ManifestWork deleted (the spoke loses the agent, AppBinding, and Secrets), their hub-side ServiceAccount and policies cleaned up, and their bootstrap token revoked.
 - **Bootstrap token rotation**: automatic. Tokens default to a 24h TTL (`spec.agentTemplate.bootstrapTokenTTL`) and are rotated when less than a quarter of the TTL remains, so a restarting spoke Pod can always re-join.
-- **Certificate renewal**: the spoke agent renews its own mTLS client certificate in place at half-life; no operator involvement.
+- **Certificate renewal**: the spoke agent renews its own mTLS client certificate in place at half-life; no operator involvement. The current expiry is visible on `status.agentPlacement.clusters[].certExpiry` (the hub reads it from its `agent/spokes` endpoint, so it tracks renewals) and via `bao agent list`.
 - **LoadBalancer address change**: the operator refreshes the advertised endpoint on the hub and pushes the new address into every ManifestWork. The changed hub address rolls the spoke-agent Pods (pod-template change), so they reconnect to the new endpoint.
 - **VaultServer deletion**: hub-side finalizers tear down every ManifestWork and revoke outstanding bootstrap tokens before the VaultServer itself is removed.
 

--- a/docs/guides/hub-spoke/deploy-hub-spoke.md
+++ b/docs/guides/hub-spoke/deploy-hub-spoke.md
@@ -239,23 +239,23 @@ spec:
 
 Because the AppBinding's `deploymentMode` is `RemoteAgent`, the SecretEngine controller configures the hub mount with `plugin_name: remote-postgres-plugin` and `spoke_name: cluster-1`. The hub proxies every credential operation to the spoke agent, which runs the real `postgresql-database-plugin` in-process against the spoke-local database.
 
-Postgres, MySQL, MariaDB, and Redis are supported through the spoke agent. MongoDB and Elasticsearch are not yet; SecretEngines for those against a `RemoteAgent` AppBinding fail with an explicit error.
+Postgres, MySQL, MariaDB, Redis, and Valkey are supported through the spoke agent. MongoDB and Elasticsearch are not; a SecretEngine for those against a `RemoteAgent` AppBinding is rejected on apply by the validating webhook.
 
 Request credentials the usual way with a `SecretAccessRequest`; see the [secret engine guides](/docs/guides/secret-engines/postgres/overview.md).
 
 ## Day-2 operations
 
-- **Adding or removing spokes**: label or relabel managed clusters; the Placement decision changes and the operator converges. Removed clusters get their ManifestWork deleted (the spoke loses the agent, AppBinding, and Secrets), their hub-side ServiceAccount and policies cleaned up, and their bootstrap token revoked.
+- **Adding or removing spokes**: label or relabel managed clusters; the Placement decision changes and the operator converges. Removed clusters get their ManifestWork deleted (the spoke loses the agent, AppBinding, and Secrets), their hub-side ServiceAccount and policies cleaned up, and their bootstrap token revoked. The spoke **Namespace is left in place** (orphaned) — it may hold non-KubeVault workloads — and the operator emits a `SpokeMountsRetained` warning Event since the hub-side database mounts the spoke configured are also retained.
 - **Bootstrap token rotation**: automatic. Tokens default to a 24h TTL (`spec.agentTemplate.bootstrapTokenTTL`) and are rotated when less than a quarter of the TTL remains, so a restarting spoke Pod can always re-join.
 - **Certificate renewal**: the spoke agent renews its own mTLS client certificate in place at half-life; no operator involvement. The current expiry is visible on `status.agentPlacement.clusters[].certExpiry` (the hub reads it from its `agent/spokes` endpoint, so it tracks renewals) and via `bao agent list`.
 - **LoadBalancer address change**: the operator refreshes the advertised endpoint on the hub and pushes the new address into every ManifestWork. The changed hub address rolls the spoke-agent Pods (pod-template change), so they reconnect to the new endpoint.
-- **VaultServer deletion**: hub-side finalizers tear down every ManifestWork and revoke outstanding bootstrap tokens before the VaultServer itself is removed.
+- **VaultServer deletion**: under `Halt`, `Delete`, or `WipeOut`, hub-side finalizers tear down every ManifestWork (each spoke loses its VaultAgent, AppBinding, and Secrets) and revoke outstanding bootstrap tokens before the VaultServer itself is removed. A `DoNotTerminate` VaultServer cannot be deleted — the validating webhook rejects it, and even if that is bypassed the spoke-agent finalizer is retained and teardown is skipped, so the spokes keep running until the policy is changed.
 
 ## Troubleshooting
 
 | Symptom | Check |
 |---|---|
-| `AgentPlacementResolved=False`, reason `WaitingForLoadBalancer` | the `vault` Service has no LoadBalancer ingress yet, or its type is not `LoadBalancer` |
+| `AgentPlacementResolved=False`, reason `WaitingForLoadBalancer` | the `vault` Service has no LoadBalancer ingress yet, or its type is not `LoadBalancer` — or, for non-cloud fleets, set the `kubevault.com/agent-hub-address` annotation to an external address instead |
 | `AgentPlacementResolved=False`, placement errors | the Placement exists in the VaultServer namespace and a `ManagedClusterSetBinding` binds the cluster set to that namespace |
 | `agentPlacementRef` silently ignored | OCM hub CRDs are not installed; the operator logs this at startup |
 | ManifestWork `Degraded` with forbidden errors | the klusterlet work agent lacks permission for KubeVault CRs; the aggregation ClusterRole shipped in the ManifestWork requires OCM >= v0.12 |

--- a/docs/guides/hub-spoke/deploy-hub-spoke.md
+++ b/docs/guides/hub-spoke/deploy-hub-spoke.md
@@ -247,7 +247,7 @@ Request credentials the usual way with a `SecretAccessRequest`; see the [secret 
 - **Adding or removing spokes**: label or relabel managed clusters; the Placement decision changes and the operator converges. Removed clusters get their ManifestWork deleted (the spoke loses the agent, AppBinding, and Secrets), their hub-side ServiceAccount and policies cleaned up, and their bootstrap token revoked.
 - **Bootstrap token rotation**: automatic. Tokens default to a 24h TTL (`spec.agentTemplate.bootstrapTokenTTL`) and are rotated when less than a quarter of the TTL remains, so a restarting spoke Pod can always re-join.
 - **Certificate renewal**: the spoke agent renews its own mTLS client certificate in place at half-life; no operator involvement.
-- **LoadBalancer address change**: the operator refreshes the advertised endpoint on the hub, pushes the new address into every ManifestWork, rotates the join Secrets, and restarts the agents.
+- **LoadBalancer address change**: the operator refreshes the advertised endpoint on the hub and pushes the new address into every ManifestWork. The changed hub address rolls the spoke-agent Pods (pod-template change), so they reconnect to the new endpoint.
 - **VaultServer deletion**: hub-side finalizers tear down every ManifestWork and revoke outstanding bootstrap tokens before the VaultServer itself is removed.
 
 ## Troubleshooting

--- a/docs/guides/hub-spoke/deploy-hub-spoke.md
+++ b/docs/guides/hub-spoke/deploy-hub-spoke.md
@@ -1,0 +1,278 @@
+---
+title: Deploy Vault in a Hub-Spoke Model | KubeVault
+menu:
+  docs_{{ .version }}:
+    identifier: deploy-hub-spoke
+    name: Deploy Hub-Spoke
+    parent: hub-spoke-guides
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeVault? Please start [here](/docs/concepts/README.md).
+
+# Deploy Vault in a Hub-Spoke Model
+
+This guide shows how to run one central Vault (OpenBao) server on a **hub** cluster and let workloads in many **spoke** clusters consume database credentials from it, even when the spoke databases are not reachable from the hub. KubeVault automates the whole rollout with [Open Cluster Management](https://open-cluster-management.io/) (OCM): you select spoke clusters with a `Placement`, and the operator does the rest.
+
+## How it works
+
+```
+HUB CLUSTER                                       SPOKE CLUSTER (one of many)
++--------------------------------------+          +--------------------------------------+
+|  VaultServer (OpenBao, HA)           |          |  VaultAgent (delivered via OCM)      |
+|   - agent/ backend: spoke-CA, tokens |          |   - join init container (bootstrap)  |
+|   - remote-<db>-plugin proxies       |  mTLS    |   - bao agent run daemon             |
+|  Service (LoadBalancer)              |<==gRPC===|   - runs db plugins in-process       |
+|   - 8200 Vault API                   |  :50053  |       |                              |
+|   - 50053 spoke gRPC proxy           |<--HTTPS--|       +--> postgres (spoke-local)    |
+|  Placement -> PlacementDecision      |  :8200   |  AppBinding (deploymentMode:         |
+|  ManifestWork per selected cluster   |          |     RemoteAgent) for hub Vault       |
++--------------------------------------+          +--------------------------------------+
+```
+
+When you set `spec.agentPlacementRef` on the hub `VaultServer`, the operator:
+
+1. initializes the OpenBao `agent/` backend (spoke-CA, gRPC proxy listener) and advertises the LoadBalancer address,
+2. resolves the `Placement` through its `PlacementDecision`s to a set of managed clusters,
+3. per cluster: creates a hub ServiceAccount (in the managed cluster's namespace on the hub) with a `VaultPolicy`/`VaultPolicyBinding` scoping its access, mints a rotating bootstrap token, and applies one `ManifestWork` carrying the `VaultAgent`, the AppBinding (with the LoadBalancer address and CA bundle), and the credential Secrets,
+4. aggregates rollout state back into `status.agentPlacement` using ManifestWork status feedback.
+
+On each spoke, the KubeVault operator reconciles the delivered `VaultAgent`: an init container runs `bao agent join` (verifying the hub with the bootstrap token's JWS signature plus the spoke-CA SPKI pin) and the main container runs `bao agent run`, connecting back to the hub over mTLS.
+
+## Before you begin
+
+- A hub cluster with the [OCM hub components](https://open-cluster-management.io/docs/getting-started/installation/start-the-control-plane/) installed (`clusteradm init`), and one or more managed clusters [registered](https://open-cluster-management.io/docs/getting-started/installation/register-a-cluster/) (`clusteradm join` + accept).
+- The KubeVault operator installed on the hub **and** on every spoke cluster (the spoke operator reconciles the delivered `VaultAgent`). See the [setup guide](/docs/setup/README.md).
+- [cert-manager](https://cert-manager.io/docs/installation/) on the hub (the VaultServer must run with TLS).
+- A cloud LoadBalancer (or equivalent) on the hub cluster, reachable from the spokes.
+
+In this guide the hub namespace is `demo` and the managed cluster is named `cluster-1`.
+
+```bash
+$ kubectl create namespace demo
+```
+
+## Step 1: Deploy the hub VaultServer
+
+Create an Issuer for the VaultServer TLS certificates:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: vault-issuer
+  namespace: demo
+spec:
+  selfSigned: {}
+```
+
+Create the `VaultServer` with a LoadBalancer service template and the agent placement reference:
+
+```yaml
+apiVersion: kubevault.com/v1alpha2
+kind: VaultServer
+metadata:
+  name: vault
+  namespace: demo
+spec:
+  version: 1.10.3
+  replicas: 3
+  tls:
+    issuerRef:
+      apiGroup: "cert-manager.io"
+      kind: Issuer
+      name: vault-issuer
+  backend:
+    raft:
+      storage:
+        storageClassName: "standard"
+        resources:
+          requests:
+            storage: 1Gi
+  unsealer:
+    secretShares: 5
+    secretThreshold: 3
+    mode:
+      kubernetesSecret:
+        secretName: vault-keys
+  serviceTemplates:
+    - alias: vault
+      spec:
+        type: LoadBalancer
+  agentPlacementRef:
+    name: db-spokes
+  agentTemplate:
+    bootstrapTokenTTL: 24h
+  terminationPolicy: WipeOut
+```
+
+The `vault` Service exposes the Vault API on port 8200 and the spoke-agent gRPC proxy on port 50053; both travel through the same LoadBalancer.
+
+## Step 2: Select spoke clusters with a Placement
+
+A `Placement` selects from the `ManagedClusterSet`s bound to its namespace. Bind a cluster set to `demo` and create the Placement referenced above:
+
+```yaml
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: default
+  namespace: demo
+spec:
+  clusterSet: default
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: db-spokes
+  namespace: demo
+spec:
+  clusterSets:
+    - default
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            purpose: database
+```
+
+Label the managed clusters that should run a spoke agent:
+
+```bash
+$ kubectl label managedcluster cluster-1 purpose=database
+```
+
+## Step 3: Watch the rollout
+
+The operator waits for the VaultServer to be unsealed and the LoadBalancer address to be provisioned, then rolls out the spokes. Track progress on the hub:
+
+```bash
+$ kubectl get vaultserver vault -n demo -o jsonpath='{.status.agentPlacement}' | jq
+{
+  "placement": "db-spokes",
+  "selected": 1,
+  "applied": 1,
+  "ready": 1,
+  "clusters": [
+    {
+      "clusterName": "cluster-1",
+      "phase": "Connected",
+      "tokenExpiry": "2026-06-13T10:00:00Z"
+    }
+  ]
+}
+```
+
+The relevant condition types are `AgentPlacementResolved`, `AgentHubInitialized`, `AgentManifestWorksApplied`, and `AgentsReady`.
+
+You can also inspect the per-cluster ManifestWork in the managed cluster's namespace on the hub:
+
+```bash
+$ kubectl get manifestwork -n cluster-1
+NAME                 AGE
+kv-demo-vault-agent  2m
+```
+
+And confirm the spoke is connected from inside a Vault pod:
+
+```bash
+$ kubectl exec -n demo vault-0 -c vault -- bao agent list
+NAME       LAST SEEN  UPTIME  HEALTH
+cluster-1  1s ago     2m      OK
+```
+
+## Step 4: Verify the spoke side
+
+On the spoke cluster, the work agent has applied the payload and the KubeVault operator has started the agent:
+
+```bash
+$ kubectl get vaultagent -n demo
+NAME          SPOKE       STATUS      AGE
+vault-agent   cluster-1   Connected   2m
+
+$ kubectl get pods -n demo
+NAME                READY   STATUS    RESTARTS   AGE
+vault-agent-agent   1/1     Running   0          2m
+
+$ kubectl get appbinding -n demo
+NAME                    TYPE                 AGE
+vault-agent-hub-vault   kubevault.com/vault  2m
+```
+
+The AppBinding points at the hub's LoadBalancer address and carries `deploymentMode: RemoteAgent` in its parameters. Spoke-side consumers authenticate to the hub Vault with a hub-issued ServiceAccount token via kubernetes auth; the matching Vault role and policy were created on the hub automatically.
+
+## Step 5: Issue credentials for a spoke-local database
+
+Now use the regular KubeVault secret engine workflow on the spoke, referencing the delivered AppBinding. The database itself only needs to be reachable from the spoke.
+
+```yaml
+apiVersion: engine.kubevault.com/v1alpha1
+kind: SecretEngine
+metadata:
+  name: postgres-engine
+  namespace: demo
+spec:
+  vaultRef:
+    name: vault-agent-hub-vault
+    namespace: demo
+  postgres:
+    databaseRef:
+      name: postgres-app
+      namespace: demo
+---
+apiVersion: engine.kubevault.com/v1alpha1
+kind: PostgresRole
+metadata:
+  name: postgres-readonly
+  namespace: demo
+spec:
+  secretEngineRef:
+    name: postgres-engine
+  creationStatements:
+    - CREATE ROLE "{{name}}" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}';
+    - GRANT SELECT ON ALL TABLES IN SCHEMA public TO "{{name}}";
+  defaultTTL: 1h
+```
+
+Because the AppBinding's `deploymentMode` is `RemoteAgent`, the SecretEngine controller configures the hub mount with `plugin_name: remote-postgres-plugin` and `spoke_name: cluster-1`. The hub proxies every credential operation to the spoke agent, which runs the real `postgresql-database-plugin` in-process against the spoke-local database.
+
+Postgres, MySQL, MariaDB, and Redis are supported through the spoke agent. MongoDB and Elasticsearch are not yet; SecretEngines for those against a `RemoteAgent` AppBinding fail with an explicit error.
+
+Request credentials the usual way with a `SecretAccessRequest`; see the [secret engine guides](/docs/guides/secret-engines/postgres/overview.md).
+
+## Day-2 operations
+
+- **Adding or removing spokes**: label or relabel managed clusters; the Placement decision changes and the operator converges. Removed clusters get their ManifestWork deleted (the spoke loses the agent, AppBinding, and Secrets), their hub-side ServiceAccount and policies cleaned up, and their bootstrap token revoked.
+- **Bootstrap token rotation**: automatic. Tokens default to a 24h TTL (`spec.agentTemplate.bootstrapTokenTTL`) and are rotated when less than a quarter of the TTL remains, so a restarting spoke Pod can always re-join.
+- **Certificate renewal**: the spoke agent renews its own mTLS client certificate in place at half-life; no operator involvement.
+- **LoadBalancer address change**: the operator refreshes the advertised endpoint on the hub, pushes the new address into every ManifestWork, rotates the join Secrets, and restarts the agents.
+- **VaultServer deletion**: hub-side finalizers tear down every ManifestWork and revoke outstanding bootstrap tokens before the VaultServer itself is removed.
+
+## Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| `AgentPlacementResolved=False`, reason `WaitingForLoadBalancer` | the `vault` Service has no LoadBalancer ingress yet, or its type is not `LoadBalancer` |
+| `AgentPlacementResolved=False`, placement errors | the Placement exists in the VaultServer namespace and a `ManagedClusterSetBinding` binds the cluster set to that namespace |
+| `agentPlacementRef` silently ignored | OCM hub CRDs are not installed; the operator logs this at startup |
+| ManifestWork `Degraded` with forbidden errors | the klusterlet work agent lacks permission for KubeVault CRs; the aggregation ClusterRole shipped in the ManifestWork requires OCM >= v0.12 |
+| spoke Pod join init container failing | bootstrap token expired (check `status.agentPlacement.clusters[].tokenExpiry`) or the hub Vault API is unreachable from the spoke |
+| VaultAgent `Connected` but SecretEngine fails | the engine type may not be supported through the spoke agent (MongoDB, Elasticsearch) |
+
+## Cleanup
+
+```bash
+# hub
+$ kubectl delete vaultserver vault -n demo     # cascades: ManifestWorks, hub SAs, policies, tokens
+$ kubectl delete placement db-spokes -n demo
+$ kubectl delete ns demo
+```
+
+## Next Steps
+
+- [VaultAgent concept](/docs/concepts/vault-server-crds/vaultagent.md)
+- [VaultServer concept](/docs/concepts/vault-server-crds/vaultserver.md)
+- [AppBinding concept](/docs/concepts/vault-server-crds/appbinding.md), in particular `spec.parameters.deploymentMode`
+- [Secret engine guides](/docs/guides/secret-engines/postgres/overview.md)


### PR DESCRIPTION
Documents the hub-spoke deployment model introduced in kubevault/operator#191.

## Concepts

- **New `VaultAgent` concept doc** (`docs/concepts/vault-server-crds/vaultagent.md`): the spoke-agent CRD — the two credential modes (`spec.bootstrap` join flow and pre-provisioned `spec.tls`, exactly one required), `spec.tokenSecretRef`, `spec.reconnect` (mapped to the pod `restartPolicy`; `backoffSeconds`/`maxBackoffSeconds` not honored), `status`, and what the operator creates (ServiceAccount, Pod, and — for standalone agents — the AppBinding; hub-managed agents get it from the ManifestWork).
- **VaultServer concept doc**: `spec.agentPlacementRef`, `spec.agentTemplate`, `status.agentPlacement` (+ per-cluster status), and the new `Agent*` condition types.
- **AppBinding concept doc**: `parameters.deploymentMode` (`Local`|`RemoteAgent`), `parameters.spokeName`, the `remote-<db>-plugin` mapping table, and the note that the `vault-type` label is a list-filter convenience only (routing comes from `deploymentMode`).

## Guide

- **New guide** `docs/guides/hub-spoke/deploy-hub-spoke.md`: deploy Vault in a hub-spoke model with OCM — Placement selection, rollout tracking via `status.agentPlacement`, spoke-side verification, issuing credentials for a spoke-local database through the agent, day-2 operations (adding/removing spokes, token rotation, cert renewal, LB address change, deletion), and troubleshooting.

## Index

- `docs/concepts/README.md` and `docs/guides/README.md` updated with the new entries; `docs/guides/hub-spoke/_index.md` added.

All concept docs were reconciled against the operator implementation in #191 — including the corrected `spec.tls` (both `caSecret` and `certSecret` required; rotating Secret contents in place does not roll the pod) and `spec.reconnect` (no agent reconnect loop; the operator maps `enabled` to `restartPolicy` and leaves a cleanly-exited agent `Disconnected`) behavior.

Operator: kubevault/operator#191.
