### PR TITLE
docs: Tenant Isolation with OpenBao Namespaces

### DIFF
--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -127,7 +127,7 @@ In a `Secret Engine`, a `role` describes an identity with a set of `permissions`
 - [PKIRole](/docs/concepts/secret-engine-crds/pki-secret-engine/pkirole.md)
 - [MongoDBRole](/docs/concepts/secret-engine-crds/database-secret-engine/mongodb.md)
 - [MySQLRole](/docs/concepts/secret-engine-crds/database-secret-engine/mysql.md)
-- [PostgresRole](/docs/concepts/secret-engine-crds/database-secret-engine/postgresrole.md)
+- [PostgresRole](/docs/concepts/secret-engine-crds/database-secret-engine/postgres.md)
 - [ElasticsearchRole](/docs/concepts/secret-engine-crds/database-secret-engine/elasticsearch.md)
 - [MariaDBRole](/docs/concepts/secret-engine-crds/database-secret-engine/mariadb.md)
 - [RedisRole](/docs/concepts/secret-engine-crds/database-secret-engine/redis.md)

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -59,6 +59,12 @@ A `VaultRelay` is a `Kubernetes CustomResourceDefinition (CRD)` which deploys an
 
 - [VaultRelay](/docs/concepts/vault-server-crds/vaultrelay.md)
 
+## NamespaceSlice
+
+A `NamespaceSlice` is a `Kubernetes CustomResourceDefinition (CRD)` the operator uses internally, modeled on `EndpointSlice`, to report the OpenBao namespaces a hub-spoke spoke needs created on the hub as part of tenant isolation. It is operator-managed only.
+
+- [NamespaceSlice](/docs/concepts/vault-server-crds/namespaceslice.md)
+
 ### Vault Unsealer Options
 When a `Vault` server is started, it starts in a `sealed` state. In this state, Vault is configured to know where and how to access the physical storage, but doesn't know how to decrypt any of it.
 

--- a/docs/concepts/policy-crds/vaultpolicybinding.md
+++ b/docs/concepts/policy-crds/vaultpolicybinding.md
@@ -147,6 +147,8 @@ token with mentioned policies.
   - `period` : `Optional`. If set indicates that the token generated using this role should never expire. The token should be renewed within the
      duration specified by this value. At each renewal, the token's TTL will be set to the value of this parameter.
 
+  - `noDefaultPolicy` : `Optional`. If `true`, sets `token_no_default_policy` on the Kubernetes auth role, so tokens issued for it carry only the policies explicitly bound here — not Vault's built-in `default` policy. Useful to minimize the token surface for machine identities, such as a hub-spoke relay's ServiceAccount.
+
 ```yaml
 spec:
   subjectRef:
@@ -159,6 +161,7 @@ spec:
       ttl: "1000"
       maxTTL: "2000"
       period: "1000"
+      noDefaultPolicy: true
 ```
 
 ### VaultPolicyBinding Status

--- a/docs/concepts/secret-engine-crds/database-secret-engine/elasticsearch.md
+++ b/docs/concepts/secret-engine-crds/database-secret-engine/elasticsearch.md
@@ -121,3 +121,14 @@ spec:
 - `phase`: Indicates whether the role successfully applied to Vault or not.
 
 - `conditions` : Represent observations of a ElasticsearchRole.
+
+## Namespace inheritance (tenant isolation)
+
+A `ElasticsearchRole` never sets or resolves an OpenBao namespace itself. It always inherits the
+**effective namespace** of the `SecretEngine` it references via `spec.secretEngineRef`
+(`SecretEngine.status.effectiveNamespace`) — empty for root, or the tenant's OpenBao
+namespace once [tenant isolation](/docs/guides/tenant-isolation/overview.md) has placed
+that engine in one. Every credential this role issues, and every revocation
+(`SecretAccessRequest`), is scoped to that same namespace automatically — no
+`ElasticsearchRole`-level configuration is needed.
+

--- a/docs/concepts/secret-engine-crds/database-secret-engine/mariadb.md
+++ b/docs/concepts/secret-engine-crds/database-secret-engine/mariadb.md
@@ -127,3 +127,14 @@ spec:
 - `phase`: Indicates whether the role successfully applied to Vault or not.
 
 - `conditions` : Represent observations of a MariaDBRole.
+
+## Namespace inheritance (tenant isolation)
+
+A `MariaDBRole` never sets or resolves an OpenBao namespace itself. It always inherits the
+**effective namespace** of the `SecretEngine` it references via `spec.secretEngineRef`
+(`SecretEngine.status.effectiveNamespace`) — empty for root, or the tenant's OpenBao
+namespace once [tenant isolation](/docs/guides/tenant-isolation/overview.md) has placed
+that engine in one. Every credential this role issues, and every revocation
+(`SecretAccessRequest`), is scoped to that same namespace automatically — no
+`MariaDBRole`-level configuration is needed.
+

--- a/docs/concepts/secret-engine-crds/database-secret-engine/mongodb.md
+++ b/docs/concepts/secret-engine-crds/database-secret-engine/mongodb.md
@@ -127,3 +127,14 @@ See [here](https://www.vaultproject.io/api/secret/databases/mongodb.html#revocat
 - `phase`: Indicates whether the role successfully applied to Vault or not.
 
 - `conditions` : Represent observations of a MongoDBRole.
+
+## Namespace inheritance (tenant isolation)
+
+A `MongoDBRole` never sets or resolves an OpenBao namespace itself. It always inherits the
+**effective namespace** of the `SecretEngine` it references via `spec.secretEngineRef`
+(`SecretEngine.status.effectiveNamespace`) — empty for root, or the tenant's OpenBao
+namespace once [tenant isolation](/docs/guides/tenant-isolation/overview.md) has placed
+that engine in one. Every credential this role issues, and every revocation
+(`SecretAccessRequest`), is scoped to that same namespace automatically — no
+`MongoDBRole`-level configuration is needed.
+

--- a/docs/concepts/secret-engine-crds/database-secret-engine/mysql.md
+++ b/docs/concepts/secret-engine-crds/database-secret-engine/mysql.md
@@ -127,3 +127,14 @@ spec:
 - `phase`: Indicates whether the role successfully applied to Vault or not.
 
 - `conditions` : Represent observations of a MySQLRole.
+
+## Namespace inheritance (tenant isolation)
+
+A `MySQLRole` never sets or resolves an OpenBao namespace itself. It always inherits the
+**effective namespace** of the `SecretEngine` it references via `spec.secretEngineRef`
+(`SecretEngine.status.effectiveNamespace`) — empty for root, or the tenant's OpenBao
+namespace once [tenant isolation](/docs/guides/tenant-isolation/overview.md) has placed
+that engine in one. Every credential this role issues, and every revocation
+(`SecretAccessRequest`), is scoped to that same namespace automatically — no
+`MySQLRole`-level configuration is needed.
+

--- a/docs/concepts/secret-engine-crds/database-secret-engine/postgres.md
+++ b/docs/concepts/secret-engine-crds/database-secret-engine/postgres.md
@@ -2,7 +2,7 @@
 title: PostgresRole | Vault Secret Engine
 menu:
   docs_{{ .version }}:
-    identifier: postgresrole-database-crds
+    identifier: postgres-database-crds
     name: PostgresRole
     parent: database-crds-concepts
     weight: 20

--- a/docs/concepts/secret-engine-crds/database-secret-engine/postgresrole.md
+++ b/docs/concepts/secret-engine-crds/database-secret-engine/postgresrole.md
@@ -139,3 +139,14 @@ rollback a create operation in the event of an error. Not every plugin type will
 - `phase`: Indicates whether the role successfully applied to Vault or not.
 
 - `conditions` : Represent observations of a PostgresRole.
+
+## Namespace inheritance (tenant isolation)
+
+A `PostgresRole` never sets or resolves an OpenBao namespace itself. It always inherits the
+**effective namespace** of the `SecretEngine` it references via `spec.secretEngineRef`
+(`SecretEngine.status.effectiveNamespace`) — empty for root, or the tenant's OpenBao
+namespace once [tenant isolation](/docs/guides/tenant-isolation/overview.md) has placed
+that engine in one. Every credential this role issues, and every revocation
+(`SecretAccessRequest`), is scoped to that same namespace automatically — no
+`PostgresRole`-level configuration is needed.
+

--- a/docs/concepts/secret-engine-crds/database-secret-engine/redis.md
+++ b/docs/concepts/secret-engine-crds/database-secret-engine/redis.md
@@ -124,3 +124,14 @@ See [here](https://www.vaultproject.io/api/secret/databases/redis.html#revocatio
 - `phase`: Indicates whether the role successfully applied to Vault or not.
 
 - `conditions` : Represent observations of a RedisRole.
+
+## Namespace inheritance (tenant isolation)
+
+A `RedisRole` never sets or resolves an OpenBao namespace itself. It always inherits the
+**effective namespace** of the `SecretEngine` it references via `spec.secretEngineRef`
+(`SecretEngine.status.effectiveNamespace`) — empty for root, or the tenant's OpenBao
+namespace once [tenant isolation](/docs/guides/tenant-isolation/overview.md) has placed
+that engine in one. Every credential this role issues, and every revocation
+(`SecretAccessRequest`), is scoped to that same namespace automatically — no
+`RedisRole`-level configuration is needed.
+

--- a/docs/concepts/secret-engine-crds/secretengine.md
+++ b/docs/concepts/secret-engine-crds/secretengine.md
@@ -116,6 +116,17 @@ Secret engines are enabled at a "path" in Vault. When a request comes to Vault, 
 
 - `spec.redis`: Specifies database(redis) secret engine configuration
 
+#### spec.namespace
+
+`spec.namespace` is an `optional` field, only applicable on an **OpenBao** distribution, that pins this SecretEngine to an explicit OpenBao namespace, overriding the namespace it would otherwise resolve to from the `VaultServer`. Supports hierarchical namespaces (e.g. `"tenant-1/project-a"`). Leave unset to use the `VaultServer`'s namespace (or root, if it has none).
+
+```yaml
+spec:
+  namespace: "acme-7f3a/project-x"
+```
+
+This field is only honored when the referenced `VaultServer` has [tenant isolation](/docs/guides/tenant-isolation/overview.md) enabled (`spec.isolateTenants: true`); with the gate off, setting it is rejected. See the tenant isolation guide for the full namespace-resolution rule, including automatic org-derived namespaces that don't require this field at all.
+
 #### spec.aws
 
 `spec.aws` specifies the configuration required to configure
@@ -570,5 +581,7 @@ Default plugin name is `mongodb-database-plugin`.
 - `observedGeneration`: Specifies the most recent generation observed for this resource. It corresponds to the resource's generation, which is updated on mutation by the API Server.
 
 - `phase`: Indicates whether the secret engine successfully configured in the Vault or not.
+
+- `effectiveNamespace`: The OpenBao namespace this secret engine is actually provisioned in (empty means root). This is the single source of truth every dependent `{db}Role` inherits, and the sticky anchor that keeps a live mount from being moved automatically when the desired namespace changes — see [tenant isolation](/docs/guides/tenant-isolation/overview.md) for the migration flow.
 
 - `conditions` : Represent observations of a SecretEngine.

--- a/docs/concepts/vault-server-crds/appbinding.md
+++ b/docs/concepts/vault-server-crds/appbinding.md
@@ -192,6 +192,10 @@ Note: the `vault-type: remote` AppBinding label is a list-filter convenience onl
 
 `spec.parameters.spokeName` is the spoke cluster identity registered with the hub's relay backend. It is required when `deploymentMode` is `RemoteRelay` and is written into database mount configurations as `spoke_name`, telling the hub which connected spoke runs the actual database plugin.
 
+### spec.parameters.isolateTenants
+
+`spec.parameters.isolateTenants` propagates the hub `VaultServer`'s `spec.isolateTenants` master gate down to a spoke, since the spoke has no hub `VaultServer` object of its own to read it from. The KubeVault operator stamps this automatically for hub-managed (placement-driven) spokes; a standalone [`VaultRelay`](/docs/concepts/vault-server-crds/vaultrelay.md) sets its own `spec.isolateTenants` instead, which is stamped here the same way. See [tenant isolation](/docs/guides/tenant-isolation/overview.md).
+
 ### spec.clientConfig
 
 `spec.clientConfig` is a required field that specifies the information to make a connection with an app.

--- a/docs/concepts/vault-server-crds/namespaceslice.md
+++ b/docs/concepts/vault-server-crds/namespaceslice.md
@@ -1,0 +1,87 @@
+---
+title: NamespaceSlice | KubeVault Concepts
+menu:
+  docs_{{ .version }}:
+    identifier: namespaceslice-vault-server-crds
+    name: NamespaceSlice
+    parent: vault-server-crds-concepts
+    weight: 14
+menu_name: docs_{{ .version }}
+section_menu_id: concepts
+---
+
+> New to KubeVault? Please start [here](/docs/concepts/README.md).
+
+# NamespaceSlice
+
+## What is NamespaceSlice
+
+A `NamespaceSlice` is a Kubernetes `CustomResourceDefinition` (CRD) the KubeVault operator uses internally to report the OpenBao namespaces a [hub-spoke](/docs/guides/hub-spoke/deploy-hub-spoke.md) spoke needs created on the hub, as part of [tenant isolation](/docs/guides/tenant-isolation/overview.md). It is modeled on the Kubernetes `EndpointSlice`: a large set of required namespaces is split across multiple `NamespaceSlice` objects (shards), each grouped back to the owning `VaultServer` by the `kubevault.com/vaultserver-name` and `kubevault.com/vaultserver-namespace` labels — the same way an `EndpointSlice` groups to a `Service` via `kubernetes.io/service-name`.
+
+`NamespaceSlice` is **internal plumbing that the operator manages automatically — you never create or edit one**. It exists to solve a specific problem in the hub-spoke topology: the hub cannot reach a spoke's Kubernetes API server directly, so it has no way to see which of the spoke's database namespaces carry the `ace.appscode.com/client-org` label and therefore need an OpenBao namespace. `NamespaceSlice` is the channel that carries that information from spoke to hub over OCM.
+
+## How it's used
+
+1. The **spoke-side operator** resolves the org-id for each local client-org database (see [tenant isolation](/docs/guides/tenant-isolation/overview.md)) and records the deduplicated, validated set it needs on the hub in one or more `NamespaceSlice` shards, under `spec.namespaces[]`.
+2. The **hub** pushes an empty `NamespaceSlice` per shard it currently tracks in the spoke's `ManifestWork`, setting only `spec.hubVaultRef` — it deliberately never sets `spec.namespaces`, so server-side-apply field ownership leaves the spoke's reported set intact (the hub owns `hubVaultRef`; the spoke owns `namespaces`). The hub reads `spec.namespaces` back through OCM ManifestWork **status feedback**, re-validates every entry, and idempotently creates each namespace with `sys/namespaces/<name>`.
+3. Until the hub creates it, a spoke `SecretEngine` that needs the namespace reports the `TenantNamespacePendingHub` condition and requeues. This is eventually consistent and self-healing.
+
+### Sharding
+
+A single `NamespaceSlice` shard holds up to `maxSpokeNamespaces` entries (operator flag `--max-spoke-namespaces`, default `256`). Once a shard fills up, the spoke rolls the overflow into the next shard (`<hub-appbinding>-1`, `-2`, …), and the hub grows how many shards it tracks — and reads back via ManifestWork status feedback — by at most one shard per reconcile, up to `maxNamespaceSliceShards` (operator flag `--max-namespace-slice-shards`, default `32`). A spoke reporting more namespaces than `maxSpokeNamespaces × maxNamespaceSliceShards` has the overflow dropped, with a warning logged by the operator.
+
+## NamespaceSlice CRD Specification
+
+Like any official Kubernetes resource, a `NamespaceSlice` object has `TypeMeta`, `ObjectMeta`, `Spec`, and `Status` sections.
+
+A sample `NamespaceSlice` object is shown below:
+
+```yaml
+apiVersion: kubevault.com/v1alpha2
+kind: NamespaceSlice
+metadata:
+  name: vault-agent-hub-vault-0
+  namespace: demo
+  labels:
+    kubevault.com/vaultserver-name: vault
+    kubevault.com/vaultserver-namespace: demo
+spec:
+  hubVaultRef:
+    name: vault
+    namespace: demo
+  namespaces:
+  - name: acme-7f3a
+    externalID: acme-7f3a
+    conditions:
+      ready: true
+status:
+  observedGeneration: 3
+  namespaceCount: 1
+```
+
+### NamespaceSlice Spec
+
+#### spec.hubVaultRef
+
+`spec.hubVaultRef` identifies the hub `VaultServer` this shard's namespaces should be created against — the same `VaultServer` the `kubevault.com/vaultserver-name` + `kubevault.com/vaultserver-namespace` labels group the shard to, so the ref and the labels always agree. It is stamped by the hub; the spoke never sets it.
+
+#### spec.namespaces
+
+`spec.namespaces` is this shard's list of required OpenBao namespaces — the analogue of a single `Endpoint` in an `EndpointSlice`. Each entry has:
+
+- `name`: the effective OpenBao namespace to provision. In the current tenant-isolation model this is the org-id.
+- `externalID`: the external identity this namespace maps to (the KubeDB Platform org-id, in string form), letting the effective namespace name diverge from the org-id in the future without changing the association.
+- `conditions.ready`: whether this namespace entry is validated and required, as reported by the spoke. A namespace explicitly marked not-ready is skipped by the hub.
+
+Set only by the spoke; the hub never writes it.
+
+### NamespaceSlice Status
+
+- `observedGeneration`: the most recent generation of the object the spoke has reconciled.
+- `namespaceCount`: mirrors `len(spec.namespaces)` — a cheap print column (`kubectl get nss`) and a bounded status-feedback scalar.
+
+## Next Steps
+
+- Learn about [Tenant Isolation with OpenBao Namespaces](/docs/guides/tenant-isolation/overview.md), including the hub-spoke section describing how the hub learns which namespaces to create.
+- Deploy the full hub-spoke model with OCM: [guide](/docs/guides/hub-spoke/deploy-hub-spoke.md).
+- Learn about the [VaultRelay](/docs/concepts/vault-server-crds/vaultrelay.md) CRD.

--- a/docs/concepts/vault-server-crds/vaultrelay.md
+++ b/docs/concepts/vault-server-crds/vaultrelay.md
@@ -73,6 +73,15 @@ spec:
   spokeName: cluster-1
 ```
 
+#### spec.isolateTenants
+
+`spec.isolateTenants` is an optional boolean field, defaulting to `false`, that opts this spoke into [tenant isolation](/docs/guides/tenant-isolation/overview.md) against the hub. Hub-managed (placement-driven) spokes inherit this automatically from the hub `VaultServer.spec.isolateTenants` and never need to set it; a standalone `VaultRelay` sets it explicitly.
+
+```yaml
+spec:
+  isolateTenants: true
+```
+
 #### spec.hubVaultRef
 
 `spec.hubVaultRef` is a required field that specifies how to reach the hub VaultServer.

--- a/docs/concepts/vault-server-crds/vaultserver.md
+++ b/docs/concepts/vault-server-crds/vaultserver.md
@@ -387,6 +387,17 @@ spec:
     podTemplate: {}                                  # pod template for the spoke-relay pods
 ```
 
+#### spec.isolateTenants
+
+`spec.isolateTenants` is an optional boolean field, the master opt-in for [tenant isolation](/docs/guides/tenant-isolation/overview.md), defaulting to `false`. When enabled on an OpenBao (namespace-capable) distribution, a `SecretEngine` whose database lives in a client-org Kubernetes namespace is automatically provisioned in an OpenBao namespace keyed on the org's identity, and every dependent `{db}Role` / `SecretAccessRequest` inherits that namespace.
+
+```yaml
+spec:
+  isolateTenants: true
+```
+
+With the gate off (the default) everything stays in the root namespace, and an explicit `SecretEngine.spec.namespace` is rejected. The admission webhook rejects `isolateTenants: true` on a distribution that does not support namespaces (Vault OSS). Turning it on, or labelling a namespace later, never moves an already-mounted engine — see the tenant isolation guide's migration section.
+
 ### VaultServer Status
 
 VaultServer Status shows the status of a Vault deployment. The status of the Vault is monitored and updated by the KubeVault operator.
@@ -453,3 +464,9 @@ status:
   - `RelayManifestWorksApplied`: every selected cluster has an applied ManifestWork.
 
   - `RelaysReady`: every selected cluster's VaultRelay reports `Connected`.
+
+- Setting `spec.isolateTenants` adds the following condition types to `status.conditions`:
+
+  - `TenantIsolationReady`: the gate is on and the backend supports namespaces.
+
+  - `TenantIsolationUnsupported`: the gate is on but the backend has no namespace support, so isolation stays inert and SecretEngines resolve to root.

--- a/docs/guides/hub-spoke/deploy-hub-spoke.md
+++ b/docs/guides/hub-spoke/deploy-hub-spoke.md
@@ -277,3 +277,4 @@ $ kubectl delete ns demo
 - [VaultServer concept](/docs/concepts/vault-server-crds/vaultserver.md)
 - [AppBinding concept](/docs/concepts/vault-server-crds/appbinding.md), in particular `spec.parameters.deploymentMode`
 - [Secret engine guides](/docs/guides/secret-engines/postgres/overview.md)
+- [Tenant Isolation with OpenBao Namespaces](/docs/guides/tenant-isolation/overview.md) — isolate each spoke's client-org databases into per-org OpenBao namespaces on the hub

--- a/docs/guides/platforms/external-vault.md
+++ b/docs/guides/platforms/external-vault.md
@@ -22,7 +22,7 @@ The KubeVault operator can perform the following operations for externally provi
 
 - Manage [AWS secret engine](https://www.vaultproject.io/docs/secrets/aws/index.html#aws-secrets-engine) using [AWSRole](/docs/concepts/secret-engine-crds/aws-secret-engine/awsrole.md) and [SecretAccessRequest](/docs/concepts/secret-engine-crds/secret-access-request.md). Guides can be found [here](/docs/guides/secret-engines/aws/overview.md).
 
-- Manage [PostgreSQL Database secret engine](https://www.vaultproject.io/api/secret/databases/postgresql.html) using [PostgresRole](/docs/concepts/secret-engine-crds/database-secret-engine/postgresrole.md) and [SecretAccessRequest](/docs/concepts/secret-engine-crds/secret-access-request.md). Guides can be found [here](/docs/guides/secret-engines/postgres/overview.md).
+- Manage [PostgreSQL Database secret engine](https://www.vaultproject.io/api/secret/databases/postgresql.html) using [PostgresRole](/docs/concepts/secret-engine-crds/database-secret-engine/postgres.md) and [SecretAccessRequest](/docs/concepts/secret-engine-crds/secret-access-request.md). Guides can be found [here](/docs/guides/secret-engines/postgres/overview.md).
 
 - Manage [MongoDB Database secret engine](https://www.vaultproject.io/api/secret/databases/mongodb.html) using [MongoDBRole](/docs/concepts/secret-engine-crds/database-secret-engine/mongodb.md) and [SecretAccessRequest](/docs/concepts/secret-engine-crds/secret-access-request.md). Guides can be found [here](/docs/guides/secret-engines/mongodb/overview.md).
 

--- a/docs/guides/secret-engines/postgres/overview.md
+++ b/docs/guides/secret-engines/postgres/overview.md
@@ -22,7 +22,7 @@ You need to be familiar with the following CRDs:
 
 - [AppBinding](/docs/concepts/vault-server-crds/auth-methods/appbinding.md)
 - [SecretEngine](/docs/concepts/secret-engine-crds/secretengine.md)
-- [PostgresRole](/docs/concepts/secret-engine-crds/database-secret-engine/postgresrole.md)
+- [PostgresRole](/docs/concepts/secret-engine-crds/database-secret-engine/postgres.md)
 
 ## Before you begin
 
@@ -133,7 +133,7 @@ Since the status is `Success`, the PostgreSQL secret engine is enabled and succe
 
 ## Create PostgreSQL Role
 
-By using [PostgresRole](/docs/concepts/secret-engine-crds/database-secret-engine/postgresrole.md), you can create a [role](https://www.vaultproject.io/docs/secrets/databases/postgresql#setup) on the Vault server in Kubernetes native way.
+By using [PostgresRole](/docs/concepts/secret-engine-crds/database-secret-engine/postgres.md), you can create a [role](https://www.vaultproject.io/docs/secrets/databases/postgresql#setup) on the Vault server in Kubernetes native way.
 
 A sample PostgresRole object is given below:
 

--- a/docs/guides/tenant-isolation/_index.md
+++ b/docs/guides/tenant-isolation/_index.md
@@ -1,0 +1,10 @@
+---
+title: Tenant Isolation | KubeVault
+menu:
+  docs_{{ .version }}:
+    identifier: tenant-isolation-guides
+    name: Tenant Isolation
+    parent: guides
+    weight: 35
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/tenant-isolation/overview.md
+++ b/docs/guides/tenant-isolation/overview.md
@@ -1,0 +1,232 @@
+---
+title: Tenant Isolation with OpenBao Namespaces | KubeVault
+menu:
+  docs_{{ .version }}:
+    identifier: tenant-isolation-overview
+    name: Overview
+    parent: tenant-isolation-guides
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeVault? Please start [here](/docs/concepts/README.md).
+
+# Tenant Isolation with OpenBao Namespaces
+
+KubeVault can automatically place a database's Vault secret engine — its mount, connection
+config, roles, and issued credentials — inside a per-tenant **OpenBao namespace**, so each
+tenant organization's secrets live together and are isolated from every other org. The
+feature is **opt-in and off by default**, and is safe to enable on a running server.
+
+> **Backend requirement:** namespaces are an **OpenBao / Vault Enterprise** capability. On
+> Vault OSS the feature stays inert (see [Capability](#capability)).
+
+## Concepts
+
+- **Tenant = organization, keyed by `org-id`.** A tenant is an *organization*, not a single
+  Kubernetes namespace. A namespace that belongs to an org is marked with a label and
+  annotation:
+
+  ```yaml
+  metadata:
+    labels:
+      ace.appscode.com/client-org: "true"     # this namespace belongs to an org
+    annotations:
+      ace.appscode.com/org-id: "acme-7f3a"     # the org identity
+  ```
+
+  One org can own **several** namespaces, all carrying the same `org-id`. They all map to a
+  single OpenBao namespace named `<org-id>`.
+
+- **Two-level opt-in.**
+  1. `VaultServer.spec.isolateTenants: true` is the **master gate** for a server.
+  2. With the gate on, each `SecretEngine` adopts a namespace based on the org that owns its
+     database — no manual `spec.namespace` needed.
+
+  With the gate **off** (the default) everything stays in the root namespace, and an
+  explicit `SecretEngine.spec.namespace` is rejected.
+
+- **The `{db}Role` → database → org chain.** A `{db}Role` (`MySQLRole`, `PostgresRole`,
+  `MongoDBRole`, …) references a `SecretEngine`; the `SecretEngine` references a database
+  AppBinding. The **database's Kubernetes namespace** defines the tenant boundary: if that
+  namespace is a client-org, the engine and all its credentials are placed in the org's
+  OpenBao namespace. Every `{db}Role` and `SecretAccessRequest` for that engine inherits the
+  same namespace.
+
+Supported engines: the database engines that have the org→DB linkage — **MySQL, MariaDB,
+Postgres, MongoDB, Redis, Elasticsearch**. AWS/GCP/Azure/PKI/KV are not namespaced by this
+feature.
+
+## Enable it
+
+Turn on the master gate on the VaultServer:
+
+```yaml
+apiVersion: kubevault.com/v1alpha2
+kind: VaultServer
+metadata:
+  name: vault
+  namespace: demo
+spec:
+  version: "1.20.0-openbao"   # a namespace-capable (OpenBao) distribution
+  isolateTenants: true
+  # …
+```
+
+Then label the tenant's database namespaces (usually done by the platform / a cluster
+admin, not by tenants):
+
+```bash
+kubectl label   ns acme-prod ace.appscode.com/client-org=true
+kubectl annotate ns acme-prod ace.appscode.com/org-id=acme-7f3a
+```
+
+Now a `SecretEngine` whose database lives in `acme-prod` is provisioned in the OpenBao
+namespace `acme-7f3a`, at `acme-7f3a/database/…`, and its dynamic credentials are issued and
+revoked there. No `SecretEngine.spec.namespace` is required.
+
+### Explicit namespace (advanced)
+
+With the gate **on**, you may still pin an engine to a specific (possibly hierarchical)
+OpenBao namespace:
+
+```yaml
+kind: SecretEngine
+spec:
+  namespace: "acme-7f3a/project-x"   # must already exist in OpenBao; only honored when isolateTenants is on
+```
+
+An explicit `spec.namespace` overrides org-derivation and must pre-exist in OpenBao.
+
+## Behavior
+
+| DB namespace | `spec.namespace` | engine state | resolves to | note |
+|---|---|---|---|---|
+| not a client-org | — | new | **root** | not a tenant |
+| client-org `X` | — | new | **X** | auto-derived |
+| client-org `X` | — | already in root | **root** | sticky; needs migration to move (below) |
+| `X`, later labelled | — | already in root | **root** | a label change never moves a live mount |
+| client-org `X` | `acme/proj` | new | **acme/proj** | explicit override wins |
+| client-org, **no `org-id`** | — | new | *(blocked)* | `TenantNamespaceUnresolved`, requeues |
+| two namespaces, same org `X` | — | new | **X (shared)** | one OpenBao namespace per org |
+| gate off | `acme` | new | **root** | explicit namespace rejected (master gate) |
+| backend not namespace-capable | any | new | **root** | `TenantIsolationUnsupported` |
+
+Two invariants make this safe:
+
+- **Existing mounts never move on their own.** Turning `isolateTenants` on, adding the
+  client-org label later, or turning the gate back off changes what an engine *would*
+  resolve to, but never re-mounts a **live** engine (which would drop its leases). Migration
+  is explicit — see below.
+- **A client-org namespace missing its `org-id` blocks, never falls back to root.** The
+  engine is not mounted (condition `TenantNamespaceUnresolved`) so org data never lands in
+  the shared root tree.
+
+### Capability
+
+Isolation needs a namespace-capable backend. If the backend is **not** capable:
+
+- **Admission** rejects `isolateTenants: true` on a distribution known to lack namespaces
+  (Vault OSS).
+- **At runtime**, the VaultServer surfaces `TenantIsolationUnsupported` and SecretEngines
+  resolve to root. When capable, it surfaces `TenantIsolationReady`.
+
+## Migrating an existing engine
+
+An engine already mounted in root (for example, provisioned before you enabled isolation)
+is **sticky** and reports `TenantMigrationPending`. Moving it is a **one-time, destructive
+re-mount that drops the engine's existing leases**, so it is admin-authorized via one of two
+annotations.
+
+**Per engine** — move just one SecretEngine:
+
+```bash
+kubectl annotate secretengine my-db kubevault.com/migrate-namespace=true
+```
+
+**In bulk, per client-org namespace** — move every SecretEngine whose database lives in a
+namespace and whose `spec.vaultRef` matches one of the listed Vault servers. The value is a
+JSON array of Vault-server AppBinding refs in `namespace/name` form:
+
+```bash
+kubectl annotate ns acme-prod \
+  'kubevault.com/migrate-vault-secrets=["kv/vault","kv/vault-2"]'
+```
+
+On either trigger the operator, for each authorized engine, unmounts the current namespace,
+re-mounts under `<org-id>`, emits a **Warning** event that leases were dropped, updates
+`status.effectiveNamespace`, and then clears the authorization (removes the per-engine
+annotation, prunes processed refs from the namespace array). Both triggers are idempotent —
+an engine already at its target is a no-op.
+
+## Conditions & status
+
+`SecretEngine.status.effectiveNamespace` is the source of truth: the OpenBao namespace the
+engine is actually provisioned in (empty = root). Every `{db}Role` inherits it.
+
+| Condition | On | Meaning |
+|---|---|---|
+| `TenantIsolationReady` | VaultServer | gate on and the backend supports namespaces |
+| `TenantIsolationUnsupported` | VaultServer | gate on but the backend has no namespace support; isolation is inert |
+| `TenantNamespaceUnresolved` | SecretEngine | the DB's namespace is a client-org but has no valid `org-id`; the engine is **not** mounted, requeued |
+| `TenantMigrationPending` | SecretEngine | the engine's desired namespace differs from where it is mounted; waiting for a migration annotation |
+| `TenantNamespacePendingHub` | SecretEngine | (hub-spoke) the derived org namespace does not yet exist on the hub; requeuing |
+
+## Hub-spoke (OCM) deployments
+
+When a spoke's database is served through the OpenBao spoke agent (see
+[Hub-Spoke Deployment](/docs/guides/hub-spoke/)), tenant isolation extends to the spoke: the
+engine mounts at `<org-id>/k8s.<spoke>.<type>.<ns>.<name>` on the hub while staying confined
+to the spoke's own prefix.
+
+- Enable it by turning on `isolateTenants` on the **hub** `VaultServer` (placement-driven
+  spokes inherit the gate automatically); a standalone `VaultAgent` sets
+  `spec.isolateTenants` explicitly.
+- The spoke derives the org from its **own** local namespace labels; the **hub** creates the
+  OpenBao namespace (spokes never create hub namespaces). Until the hub creates it, the
+  engine reports `TenantNamespacePendingHub` and requeues.
+
+> **Security requirement:** on hub-spoke, per-spoke isolation is enforced by a Vault policy
+> that embeds the cluster name as the literal prefix `k8s.<cluster>.`. This holds **only if
+> the OCM managed-cluster name is a strict RFC-1123 DNS label** (lowercase alphanumeric and
+> `-`, no dots). KubeVault validates this and fails closed on a non-conforming name.
+
+## Non-goals & limitations
+
+- Only the **database** engines (with an org→DB linkage) are namespaced.
+- Auto-derived namespaces are a **single `<org-id>` segment**; hierarchical namespaces
+  (`org/project`) are available only via an explicit `spec.namespace`.
+- The operator **never garbage-collects** an org's OpenBao namespace when its last engine is
+  removed (an empty namespace is cheap and the namespace belongs to the org, which may still
+  own other engines).
+- Turning `isolateTenants` off is **non-destructive**: it never evacuates an
+  already-namespaced engine; it surfaces `TenantMigrationPending` and waits for the annotation.
+
+## Reference
+
+**VaultServer**
+
+- `spec.isolateTenants` (bool, default `false`) — master opt-in.
+
+**SecretEngine**
+
+- `spec.namespace` (string) — explicit OpenBao namespace; only honored when the server's
+  `isolateTenants` is on.
+- `status.effectiveNamespace` (string) — the namespace the engine is provisioned in.
+
+**Namespace keys**
+
+- label `ace.appscode.com/client-org: "true"` — the namespace belongs to an org.
+- annotation `ace.appscode.com/org-id: <slug>` — the org identity (the OpenBao namespace name).
+
+**Migration annotations**
+
+- `kubevault.com/migrate-namespace: "true"` — on a SecretEngine; migrate that engine.
+- `kubevault.com/migrate-vault-secrets: '["<ns>/<name>", …]'` — on a client-org Namespace;
+  migrate matching engines in bulk.
+
+## Next steps
+
+- [Deploy Vault in a Hub-Spoke Model](/docs/guides/hub-spoke/)
+- [Secret Engine Guides](/docs/guides/secret-engines/)

--- a/docs/guides/tenant-isolation/overview.md
+++ b/docs/guides/tenant-isolation/overview.md
@@ -71,6 +71,13 @@ metadata:
 spec:
   version: "1.20.0-openbao"   # a namespace-capable (OpenBao) distribution
   isolateTenants: true
+  backend:
+    raft:
+      storage:
+        storageClassName: "standard"
+        resources:
+          requests:
+            storage: 1Gi
   # …
 ```
 

--- a/docs/guides/tenant-isolation/overview.md
+++ b/docs/guides/tenant-isolation/overview.md
@@ -207,7 +207,9 @@ can shard across several slices, all grouped to their `VaultServer` by the
 `kubevault.com/vaultserver-name` and `kubevault.com/vaultserver-namespace` labels.
 
 `NamespaceSlice` is internal plumbing the operator manages automatically — you never create or
-edit one; it is described here only to explain the hub-spoke flow.
+edit one; it is described here only to explain the hub-spoke flow. See the
+[NamespaceSlice concept](/docs/concepts/vault-server-crds/namespaceslice.md) for its full CRD
+reference, including the `maxSpokeNamespaces` / `maxNamespaceSliceShards` sharding bounds.
 
 > **Security requirement:** on hub-spoke, per-spoke isolation is enforced by a Vault policy
 > that embeds the cluster name as the literal prefix `k8s.<cluster>.`. This holds **only if

--- a/docs/guides/tenant-isolation/overview.md
+++ b/docs/guides/tenant-isolation/overview.md
@@ -175,17 +175,32 @@ engine is actually provisioned in (empty = root). Every `{db}Role` inherits it.
 
 ## Hub-spoke (OCM) deployments
 
-When a spoke's database is served through the OpenBao spoke agent (see
+When a spoke's database is served through the OpenBao spoke relay (see
 [Hub-Spoke Deployment](/docs/guides/hub-spoke/)), tenant isolation extends to the spoke: the
 engine mounts at `<org-id>/k8s.<spoke>.<type>.<ns>.<name>` on the hub while staying confined
 to the spoke's own prefix.
 
 - Enable it by turning on `isolateTenants` on the **hub** `VaultServer` (placement-driven
-  spokes inherit the gate automatically); a standalone `VaultAgent` sets
+  spokes inherit the gate automatically); a standalone `VaultRelay` sets
   `spec.isolateTenants` explicitly.
 - The spoke derives the org from its **own** local namespace labels; the **hub** creates the
   OpenBao namespace (spokes never create hub namespaces). Until the hub creates it, the
   engine reports `TenantNamespacePendingHub` and requeues.
+
+### How the hub learns which namespaces to create
+
+The hub cannot see the spoke's client-org namespaces directly, so each spoke reports the
+OpenBao namespaces it needs through a **`NamespaceSlice`** — a namespaced resource modeled on
+Kubernetes `EndpointSlice`. The spoke operator maintains a slice whose `spec.namespaces[]`
+lists one entry per required namespace (`name` — the effective namespace, i.e. the org-id;
+`externalID` — the org identity; `conditions.ready`), and the hub reads it back over the same
+OCM ManifestWork status-feedback channel it already uses for relay health, then idempotently
+creates each namespace with `sys/namespaces/<org-id>`. As with `EndpointSlice`, a large set
+can shard across several slices, all grouped to their `VaultServer` by the
+`kubevault.com/vaultserver-name` and `kubevault.com/vaultserver-namespace` labels.
+
+`NamespaceSlice` is internal plumbing the operator manages automatically — you never create or
+edit one; it is described here only to explain the hub-spoke flow.
 
 > **Security requirement:** on hub-spoke, per-spoke isolation is enforced by a Vault policy
 > that embeds the cluster name as the literal prefix `k8s.<cluster>.`. This holds **only if
@@ -225,6 +240,13 @@ to the spoke's own prefix.
 - `kubevault.com/migrate-namespace: "true"` — on a SecretEngine; migrate that engine.
 - `kubevault.com/migrate-vault-secrets: '["<ns>/<name>", …]'` — on a client-org Namespace;
   migrate matching engines in bulk.
+
+**NamespaceSlice** (hub-spoke; operator-managed, read-only to users)
+
+- `spec.namespaces[]` — required OpenBao namespaces, each `{name, externalID, conditions.ready}`.
+- `status.namespaceCount` — number of entries (shown as the `NamespaceCount` print column).
+- labels `kubevault.com/vaultserver-name` + `kubevault.com/vaultserver-namespace` — group
+  the slice(s) to their owning `VaultServer`.
 
 ## Next steps
 


### PR DESCRIPTION
## Summary

Documents the tenant-namespace feature (automatic per-org OpenBao namespaces) across the guides and CRD concept references.

### New guide

Adds `docs/guides/tenant-isolation/` (`_index.md` + `overview.md`, mirroring the existing `guides/hub-spoke/` layout; weight `35`, after Secret Engines):

- **Concepts** — tenant = org keyed by `org-id`, the `ace.appscode.com/client-org` label + `ace.appscode.com/org-id` annotation model, the two-level opt-in, and the `{db}Role → database → org` chain.
- **Enabling** — `VaultServer.spec.isolateTenants`, labelling tenant DB namespaces, and the explicit-`spec.namespace` escape hatch.
- **Behavior matrix** — auto-derive, stickiness, block-on-missing-org-id, shared-org, capability gating.
- **Migration** — the `kubevault.com/migrate-namespace` (per-engine) and `kubevault.com/migrate-vault-secrets` (bulk) annotations, and the lease-drop warning.
- **Conditions & status** — `effectiveNamespace` + the full condition table (including `TenantNamespacePendingHub`).
- **Hub-spoke** — enabling isolation on spokes, how the hub learns which namespaces to create from a spoke's `NamespaceSlice` (EndpointSlice-style, sharded), and the cluster-name (RFC-1123) security requirement.
- **Non-goals / reference** — fields, namespace keys, and annotation reference.

### New and updated CRD concept docs

- **New**: `NamespaceSlice` concept page under `vault-server-crds` (spec, status, sharding), linked from the concepts README and the guide's hub-spoke section.
- **VaultServer**: `spec.isolateTenants`, plus the `TenantIsolationReady` / `TenantIsolationUnsupported` conditions.
- **VaultRelay**: `spec.isolateTenants` (the standalone/hub-spoke propagation path).
- **AppBinding**: `spec.parameters.isolateTenants` (how the gate reaches a spoke's `VaultServerConfiguration`).
- **SecretEngine**: `spec.namespace` (explicit override) and `status.effectiveNamespace`.
- **VaultPolicyBinding**: `spec.subjectRef.kubernetes.noDefaultPolicy`.
- **{db}Role** (MySQLRole, PostgresRole, MongoDBRole, MariaDBRole, RedisRole, ElasticsearchRole): a "Namespace inheritance (tenant isolation)" section explaining each role inherits its `SecretEngine`'s effective namespace rather than resolving one itself.
- Cross-link from the hub-spoke deploy guide to this new guide.

### Housekeeping

- Renamed `postgresrole.md` → `postgres.md` (and its menu identifier) so all six database-secret-engine concept pages follow the same `{engine}.md` naming; updated the three referencing links.
- Fixed the enable-it example to include the required `spec.backend`, which the codespan schema checker validates against.

## Dependency

CI validates every embedded YAML example against the installed CRDs, pulled from `kubevault/installer`'s `master` branch. `spec.isolateTenants` and the `NamespaceSlice` CRD are new fields from `kubevault/operator#213`'s apimachinery bump, synced into the installer charts in kubevault/installer#461 — that PR needs to merge before this one's CI goes green.
