### PR TITLE
docs: remove stale VaultRelay/VaultRelayTemplate spec.image references

### DIFF
--- a/docs/concepts/vault-server-crds/vaultrelay.md
+++ b/docs/concepts/vault-server-crds/vaultrelay.md
@@ -53,7 +53,6 @@ spec:
   bootstrap:
     joinSecretRef:
       name: vault-agent-join
-  image: ghcr.io/kubevault/spoke-relay:v0.1.0
   reconnect:
     enabled: true
     backoffSeconds: 5
@@ -124,9 +123,12 @@ In hub-managed deployments the operator creates and rotates this Secret automati
 
 > **Note:** Set exactly one credential source — `spec.bootstrap` (this join flow) or [`spec.tls`](#spectls) (pre-provisioned certificates). The operator rejects a `VaultRelay` that sets neither or both.
 
-#### spec.image
+#### Container image
 
-`spec.image` is an optional field that overrides the spoke-relay container image.
+`VaultRelay` has no `spec.image` field — the spoke-relay container image is always resolved automatically from the [AppBinding](/docs/concepts/vault-server-crds/appbinding.md) fronting the hub Vault (`status.appBindingRef`): the operator reads that AppBinding's `spec.version` and looks up the matching `VaultServerVersion`'s `spec.vault.image`. This guarantees the relay always runs an image that matches the hub Vault it talks to.
+
+- **Hub-managed deployments**: `spec.version` is stamped automatically by the hub onto the AppBinding it delivers, from the hub `VaultServer`'s own `spec.version` — nothing to configure.
+- **Standalone relays**: the operator authors the AppBinding itself but has no source for the hub's `VaultServerVersion` name, so it leaves `spec.version` unset. You must set it by hand (`kubectl edit appbinding <relay-name>-hub-vault`, or via whatever process manages the AppBinding) to the name of a `VaultServerVersion` matching the hub Vault, or the relay Pod is never built — the `VaultRelay` fails its reconcile with an `AppBindingVersionRequired` condition and Event until you do.
 
 #### spec.tokenSecretRef
 
@@ -183,7 +185,7 @@ In hub-managed deployments, `status.phase` is scraped back to the hub through `M
 For every `VaultRelay`, the spoke-side KubeVault operator provisions:
 
 - a **ServiceAccount** for the relay Pod
-- the **spoke-relay Pod**: with `spec.bootstrap`, an init container runs `bao relay join` (verifying the hub via the bootstrap token's JWS signature plus the SPKI pin) and writes credentials to an emptyDir; with `spec.tls`, the pre-provisioned certificates are projected read-only and there is no init container. The main container runs `bao relay run -server=<hub>:<grpcPort> -credentials-dir=...`. The Pod is replaced when its template changes (image, podTemplate, resources, or the referenced Secrets).
+- the **spoke-relay Pod**: with `spec.bootstrap`, an init container runs `bao relay join` (verifying the hub via the bootstrap token's JWS signature plus the SPKI pin) and writes credentials to an emptyDir; with `spec.tls`, the pre-provisioned certificates are projected read-only and there is no init container. The main container runs `bao relay run -server=<hub>:<grpcPort> -credentials-dir=...`, using the [image resolved from the hub AppBinding](#container-image). The Pod is replaced when its template changes (resolved image, podTemplate, resources, or the referenced Secrets).
 - an **AppBinding** for the hub VaultServer (standalone relays only). Its parameters carry `deploymentMode: RemoteRelay` and `spokeName`, which the secret engine machinery uses to route database mounts through the hub's `remote-<db>-plugin` proxies. In hub-managed deployments this AppBinding is instead delivered and owned by the hub's `ManifestWork` (labeled `app.kubernetes.io/managed-by: kubevault-hub`), and the operator defers to that copy. See the [AppBinding concept](/docs/concepts/vault-server-crds/appbinding.md).
 
 ## Next Steps

--- a/docs/concepts/vault-server-crds/vaultserver.md
+++ b/docs/concepts/vault-server-crds/vaultserver.md
@@ -382,10 +382,11 @@ For each selected cluster the operator creates a ServiceAccount (in the managed 
 spec:
   relayTemplate:
     namespace: demo                                  # namespace on the managed cluster (defaults to the VaultServer's namespace)
-    image: ghcr.io/kubevault/spoke-relay:v0.1.0      # spoke-relay container image
     bootstrapTokenTTL: 24h                           # TTL and rotation period of bootstrap tokens (default 24h, minimum 1h)
     podTemplate: {}                                  # pod template for the spoke-relay pods
 ```
+
+> **Note:** `relayTemplate` has no `image` field — there is no per-`VaultServer` override for the spoke-relay container image. Every spoke relay's image is resolved automatically from this `VaultServer`'s own `spec.version` (via the `VaultServerVersion` it names), so a spoke relay always tracks the hub Vault version it talks to. See [VaultRelay's container image](/docs/concepts/vault-server-crds/vaultrelay.md#container-image).
 
 #### spec.isolateTenants
 

--- a/docs/guides/hub-spoke/deploy-hub-spoke.md
+++ b/docs/guides/hub-spoke/deploy-hub-spoke.md
@@ -77,7 +77,7 @@ metadata:
   name: vault
   namespace: demo
 spec:
-  version: 1.10.3
+  version: "sigilr-2.6.1.1" # a namespace-capable distribution (Sigilr, an OpenBao derivative)
   replicas: 3
   tls:
     issuerRef:

--- a/docs/guides/tenant-isolation/overview.md
+++ b/docs/guides/tenant-isolation/overview.md
@@ -69,7 +69,7 @@ metadata:
   name: vault
   namespace: demo
 spec:
-  version: "1.20.0-openbao"   # a namespace-capable (OpenBao) distribution
+  version: "sigilr-2.6.1.1"   # a namespace-capable distribution (Sigilr, an OpenBao derivative)
   isolateTenants: true
   backend:
     raft:


### PR DESCRIPTION
## Summary

`VaultRelay.spec.image` and `VaultServer.spec.relayTemplate.image` were removed from the API (kubevault/apimachinery#166, kubevault/operator#225): the spoke-relay container image is now always resolved automatically from the hub AppBinding's `spec.version` against the matching `VaultServerVersion`, so a relay always tracks the hub Vault version it talks to. There is no per-relay or per-`VaultServer` image override anymore.

This drops the stale `image:` fields from the sample manifests in `vaultrelay.md` and `vaultserver.md`, replaces the `VaultRelay` `spec.image` section with an explanation of how the image is actually resolved (including the standalone-relay requirement to set the AppBinding's `spec.version` by hand), and notes the removal on `VaultServer.spec.relayTemplate`.

Also fixes two version-consistency issues in the OpenBao/Sigilr-dependent guides:

- `docs/guides/tenant-isolation/overview.md`'s enable-it example referenced `spec.version: "1.20.0-openbao"`, which isn't a real `VaultServerVersion` catalog entry — it failed `codespan-schema-checker` CI with `using unknown VaultServer version 1.20.0-openbao`.
- `docs/guides/hub-spoke/deploy-hub-spoke.md`'s hub `VaultServer` example used a plain Vault OSS version (`1.10.3`) despite the guide describing itself as running "one central Vault (OpenBao) server" and linking to the tenant-isolation guide, both of which require a namespace-capable distribution.

Both now consistently use `sigilr-2.6.1.1`, a real, namespace-capable (Sigilr, an OpenBao derivative) `VaultServerVersion` from `kubevault.dev/installer`.

## ⚠️ CI dependency

`sigilr-2.6.1.1` landed on `kubevault.dev/installer`'s `master` today (`installer@ef9f89db`, "Add OpenBao Version 2.6.1 (#466)") and is **not yet in any published `kubevault-catalog` chart release** — checked the live chart index directly; even the newest RC (`v2026.7.24-rc.2`, Jul 25) lacks it. This PR's `Check codespan schema` job installs the catalog via `helm install kubevault-catalog appscode/kubevault-catalog` with no version pin, so that job will stay red until a new `kubevault-catalog` chart is released from installer `master`.

Same kind of dependency #488 had on `kubevault/installer#461` being released first.

Surfaced while fixing kubevault/operator#224.
