### PR TITLE
docs: fix invalid partial SecretEngine snippet in tenant-isolation guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,4 +81,11 @@ jobs:
 
       - name: Check codespan schema
         run: |
-          codespan-schema-checker --content=./docs
+          git clone https://github.com/kubevault/installer.git
+          cd installer
+          git checkout $(git describe --tags --abbrev=0 2>/dev/null || echo master)
+          cd ..
+          git clone https://github.com/kmodules/resource-metadata.git
+          mv resource-metadata/hub /tmp
+          rm -rf resource-metadata
+          codespan-schema-checker --kubevault-catalog-dir=./installer/catalog --content=./docs

--- a/docs/concepts/vault-server-crds/storage/azure.md
+++ b/docs/concepts/vault-server-crds/storage/azure.md
@@ -24,7 +24,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.2.0"
+  version: "1.18.4"
   backend:
     azure:
       accountName: "vault-ac"

--- a/docs/concepts/vault-server-crds/storage/consul.md
+++ b/docs/concepts/vault-server-crds/storage/consul.md
@@ -24,7 +24,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.2.0"
+  version: "1.18.4"
   serviceTemplates:
   - alias: vault
     metadata:

--- a/docs/concepts/vault-server-crds/storage/dynamodb.md
+++ b/docs/concepts/vault-server-crds/storage/dynamodb.md
@@ -24,7 +24,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.2.0"
+  version: "1.18.4"
   backend:
     dynamodb:
       table: "my-vault-table"

--- a/docs/concepts/vault-server-crds/storage/etcd.md
+++ b/docs/concepts/vault-server-crds/storage/etcd.md
@@ -24,7 +24,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.2.0"
+  version: "1.18.4"
   backend:
     etcd:
       address: "http://example.etcd.svc:2379"

--- a/docs/concepts/vault-server-crds/storage/filesystem.md
+++ b/docs/concepts/vault-server-crds/storage/filesystem.md
@@ -24,7 +24,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.2.3"
+  version: "1.18.4"
   serviceTemplates:
   - alias: vault
     metadata:

--- a/docs/concepts/vault-server-crds/storage/gcs.md
+++ b/docs/concepts/vault-server-crds/storage/gcs.md
@@ -24,7 +24,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.2.0"
+  version: "1.18.4"
   backend:
     gcs:
       bucket: "my-vault-storage"

--- a/docs/concepts/vault-server-crds/storage/inmem.md
+++ b/docs/concepts/vault-server-crds/storage/inmem.md
@@ -24,7 +24,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.2.0"
+  version: "1.18.4"
   backend:
     inmem: {}
 ```

--- a/docs/concepts/vault-server-crds/storage/mysql.md
+++ b/docs/concepts/vault-server-crds/storage/mysql.md
@@ -24,7 +24,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.2.0"
+  version: "1.18.4"
   backend:
     mysql:
       address: "my.mysql.com:3306"

--- a/docs/concepts/vault-server-crds/storage/postgresql.md
+++ b/docs/concepts/vault-server-crds/storage/postgresql.md
@@ -24,7 +24,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.2.0"
+  version: "1.18.4"
   backend:
     postgresql:
       connectionURLSecret: "my-postgres-conn"

--- a/docs/concepts/vault-server-crds/storage/raft.md
+++ b/docs/concepts/vault-server-crds/storage/raft.md
@@ -24,7 +24,7 @@ metadata:
   namespace: default
 spec:
   replicas: 3
-  version: 1.7.3
+  version: "1.18.4"
   serviceTemplates:
     - alias: vault
       metadata:

--- a/docs/concepts/vault-server-crds/storage/s3.md
+++ b/docs/concepts/vault-server-crds/storage/s3.md
@@ -24,7 +24,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.2.0"
+  version: "1.18.4"
   backend:
     s3:
       bucket: "my-vault-bucket"

--- a/docs/concepts/vault-server-crds/storage/swift.md
+++ b/docs/concepts/vault-server-crds/storage/swift.md
@@ -24,7 +24,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.2.0"
+  version: "1.18.4"
   backend:
     swift:
       authURL: "https://auth.cloud.ovh.net/v2.0/"

--- a/docs/examples/guides/policy-management/vaultserver.yaml
+++ b/docs/examples/guides/policy-management/vaultserver.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.2.3"
+  version: "1.18.4"
   backend:
     inmem: {}
   unsealer:

--- a/docs/examples/guides/policy-management/vaultserverversion.yaml
+++ b/docs/examples/guides/policy-management/vaultserverversion.yaml
@@ -1,13 +1,13 @@
 apiVersion: catalog.kubevault.com/v1alpha1
 kind: VaultServerVersion
 metadata:
-  name: 1.2.0
+  name: '1.18.4'
 spec:
-  version: 1.2.0
-  deprecated: false
-  vault:
-    image: vault:1.2.0
-  unsealer:
-    image: kubevault/vault-unsealer:v0.3.0
+  distribution: Vault
   exporter:
-    image: kubevault/vault-exporter:0.1.0
+    image: ghcr.io/kubevault/vault-exporter:v0.1.1
+  unsealer:
+    image: ghcr.io/kubevault/vault-unsealer:v0.25.0
+  vault:
+    image: ghcr.io/appscode-images/vault:1.18.4
+  version: 1.18.4

--- a/docs/examples/guides/provider/aks/my-vault.yaml
+++ b/docs/examples/guides/provider/aks/my-vault.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.2.0"
+  version: "1.18.4"
   backend:
     azure:
       container: demo-vault

--- a/docs/examples/guides/provider/aks/vaultserverversion.yaml
+++ b/docs/examples/guides/provider/aks/vaultserverversion.yaml
@@ -1,13 +1,13 @@
 apiVersion: catalog.kubevault.com/v1alpha1
 kind: VaultServerVersion
 metadata:
-  name: 1.2.0
+  name: '1.18.4'
 spec:
-  version: 1.2.0
-  deprecated: false
-  vault:
-    image: vault:1.2.0
-  unsealer:
-    image: kubevault/vault-unsealer:v0.3.0
+  distribution: Vault
   exporter:
-    image: kubevault/vault-exporter:0.1.0
+    image: ghcr.io/kubevault/vault-exporter:v0.1.1
+  unsealer:
+    image: ghcr.io/kubevault/vault-unsealer:v0.25.0
+  vault:
+    image: ghcr.io/appscode-images/vault:1.18.4
+  version: 1.18.4

--- a/docs/examples/guides/provider/eks/my-vault.yaml
+++ b/docs/examples/guides/provider/eks/my-vault.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.2.0"
+  version: "1.18.4"
   backend:
     s3:
       bucket: "demo-vault-3"

--- a/docs/examples/guides/provider/gke/my-vault.yaml
+++ b/docs/examples/guides/provider/gke/my-vault.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.2.0"
+  version: "1.18.4"
   backend:
     gcs:
       bucket: "demo-vault"

--- a/docs/examples/guides/provider/gke/vaultserverversion.yaml
+++ b/docs/examples/guides/provider/gke/vaultserverversion.yaml
@@ -1,12 +1,13 @@
 apiVersion: catalog.kubevault.com/v1alpha1
 kind: VaultServerVersion
 metadata:
-  name: 1.2.0
+  name: '1.18.4'
 spec:
+  distribution: Vault
   exporter:
-    image: kubevault/vault-exporter:v0.1.0
+    image: ghcr.io/kubevault/vault-exporter:v0.1.1
   unsealer:
-    image: kubevault/vault-unsealer:v0.3.0
+    image: ghcr.io/kubevault/vault-unsealer:v0.25.0
   vault:
-    image: vault:1.2.0
-  version: 1.2.0
+    image: ghcr.io/appscode-images/vault:1.18.4
+  version: 1.18.4

--- a/docs/examples/guides/provider/multi-cluster/my-vault.yaml
+++ b/docs/examples/guides/provider/multi-cluster/my-vault.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.2.0"
+  version: "1.18.4"
   backend:
     gcs:
       bucket: "demo-vault"

--- a/docs/examples/guides/provider/multi-cluster/vaultserverversion.yaml
+++ b/docs/examples/guides/provider/multi-cluster/vaultserverversion.yaml
@@ -1,12 +1,13 @@
 apiVersion: catalog.kubevault.com/v1alpha1
 kind: VaultServerVersion
 metadata:
-  name: 1.2.0
+  name: '1.18.4'
 spec:
+  distribution: Vault
   exporter:
-    image: kubevault/vault-exporter:v0.1.0
+    image: ghcr.io/kubevault/vault-exporter:v0.1.1
   unsealer:
-    image: kubevault/vault-unsealer:v0.3.0
+    image: ghcr.io/kubevault/vault-unsealer:v0.25.0
   vault:
-    image: vault:1.2.0
-  version: 1.2.0
+    image: ghcr.io/appscode-images/vault:1.18.4
+  version: 1.18.4

--- a/docs/examples/guides/secret-engines/aws/vaultserver.yaml
+++ b/docs/examples/guides/secret-engines/aws/vaultserver.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
   namespace: demo
 spec:
-  version: 1.7.3
+  version: "1.18.4"
   replicas: 3
   backend:
     raft:

--- a/docs/examples/guides/secret-engines/azure/vaultserver.yaml
+++ b/docs/examples/guides/secret-engines/azure/vaultserver.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
   namespace: demo
 spec:
-  version: 1.7.3
+  version: "1.18.4"
   replicas: 3
   backend:
     raft:

--- a/docs/examples/guides/secret-engines/elasticsearch/vaultserver.yaml
+++ b/docs/examples/guides/secret-engines/elasticsearch/vaultserver.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
   namespace: demo
 spec:
-  version: 1.7.3
+  version: "1.18.4"
   replicas: 3
   backend:
     raft:

--- a/docs/examples/guides/secret-engines/gcp/vaultserver.yaml
+++ b/docs/examples/guides/secret-engines/gcp/vaultserver.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
   namespace: demo
 spec:
-  version: 1.7.3
+  version: "1.18.4"
   replicas: 3
   backend:
     raft:

--- a/docs/examples/guides/secret-engines/kv/vaultserver.yaml
+++ b/docs/examples/guides/secret-engines/kv/vaultserver.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
   namespace: demo
 spec:
-  version: 1.7.3
+  version: "1.18.4"
   replicas: 3
   backend:
     raft:

--- a/docs/examples/guides/secret-engines/mariadb/vaultserver.yaml
+++ b/docs/examples/guides/secret-engines/mariadb/vaultserver.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
   namespace: demo
 spec:
-  version: 1.7.3
+  version: "1.18.4"
   replicas: 3
   backend:
     raft:

--- a/docs/examples/guides/secret-engines/mongodb/vaultserver.yaml
+++ b/docs/examples/guides/secret-engines/mongodb/vaultserver.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
   namespace: demo
 spec:
-  version: 1.7.3
+  version: "1.18.4"
   replicas: 3
   backend:
     raft:

--- a/docs/examples/guides/secret-engines/mysql/vaultserver.yaml
+++ b/docs/examples/guides/secret-engines/mysql/vaultserver.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
   namespace: demo
 spec:
-  version: 1.7.3
+  version: "1.18.4"
   replicas: 3
   backend:
     raft:

--- a/docs/examples/guides/secret-engines/pki/vaultserver.yaml
+++ b/docs/examples/guides/secret-engines/pki/vaultserver.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
   namespace: demo
 spec:
-  version: 1.7.3
+  version: "1.18.4"
   replicas: 3
   backend:
     raft:

--- a/docs/examples/guides/secret-engines/postgres/vaultserver.yaml
+++ b/docs/examples/guides/secret-engines/postgres/vaultserver.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
   namespace: demo
 spec:
-  version: 1.7.3
+  version: "1.18.4"
   replicas: 3
   backend:
     raft:

--- a/docs/examples/guides/secret-engines/secret-access-request/vaultserver.yaml
+++ b/docs/examples/guides/secret-engines/secret-access-request/vaultserver.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
   namespace: demo
 spec:
-  version: 1.7.3
+  version: "1.18.4"
   replicas: 3
   backend:
     raft:

--- a/docs/examples/guides/secret-engines/secret-role-binding/vaultserver.yaml
+++ b/docs/examples/guides/secret-engines/secret-role-binding/vaultserver.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
   namespace: demo
 spec:
-  version: 1.7.3
+  version: "1.18.4"
   replicas: 3
   backend:
     raft:

--- a/docs/examples/guides/vault-server/vaultserver.yaml
+++ b/docs/examples/guides/vault-server/vaultserver.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.2.3"
+  version: "1.18.4"
   serviceTemplates:
   - alias: vault
     metadata:

--- a/docs/examples/guides/vault-server/vaultserverversion.yaml
+++ b/docs/examples/guides/vault-server/vaultserverversion.yaml
@@ -1,12 +1,13 @@
 apiVersion: catalog.kubevault.com/v1alpha1
 kind: VaultServerVersion
 metadata:
-  name: 1.2.2
+  name: '1.18.4'
 spec:
+  distribution: Vault
   exporter:
-    image: kubevault/vault-exporter:v0.1.0
+    image: ghcr.io/kubevault/vault-exporter:v0.1.1
   unsealer:
-    image: kubevault/vault-unsealer:v0.3.0
+    image: ghcr.io/kubevault/vault-unsealer:v0.25.0
   vault:
-    image: vault:1.2.2
-  version: 1.2.2
+    image: ghcr.io/appscode-images/vault:1.18.4
+  version: 1.18.4

--- a/docs/examples/monitoring/vault-operator/vault-server-builtin.yaml
+++ b/docs/examples/monitoring/vault-operator/vault-server-builtin.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: 1.2.0
+  version: "1.18.4"
   serviceTemplates:
   - alias: vault
     metadata:

--- a/docs/examples/monitoring/vault-operator/vault-server-coreos.yaml
+++ b/docs/examples/monitoring/vault-operator/vault-server-coreos.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: 1.2.0
+  version: "1.18.4"
   serviceTemplates:
   - alias: vault
     metadata:

--- a/docs/examples/monitoring/vault-server/vault-server-builtin.yaml
+++ b/docs/examples/monitoring/vault-server/vault-server-builtin.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: 1.2.0
+  version: "1.18.4"
   serviceTemplates:
   - alias: vault
     metadata:

--- a/docs/examples/monitoring/vault-server/vault-server-coreos.yaml
+++ b/docs/examples/monitoring/vault-server/vault-server-coreos.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: 1.2.0
+  version: "1.18.4"
   serviceTemplates:
   - alias: vault
     metadata:

--- a/docs/examples/vaultserver_inmem_k8s_unsealer.yaml
+++ b/docs/examples/vaultserver_inmem_k8s_unsealer.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.2.0"
+  version: "1.18.4"
   backend:
     inmem: {}
   unsealer:

--- a/docs/guides/monitoring/vault-server/builtin.md
+++ b/docs/guides/monitoring/vault-server/builtin.md
@@ -90,7 +90,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: 1.2.0
+  version: "1.18.4"
   serviceTemplates:
   - alias: vault
     metadata:

--- a/docs/guides/monitoring/vault-server/coreos.md
+++ b/docs/guides/monitoring/vault-server/coreos.md
@@ -28,7 +28,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: 1.2.0
+  version: "1.18.4"
   serviceTemplates:
   - alias: vault
     metadata:

--- a/docs/guides/platforms/aks.md
+++ b/docs/guides/platforms/aks.md
@@ -93,7 +93,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.2.0"
+  version: "1.18.4"
   backend:
     azure:
       container: demo-vault

--- a/docs/guides/platforms/eks.md
+++ b/docs/guides/platforms/eks.md
@@ -70,7 +70,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.2.0"
+  version: "1.18.4"
   backend:
     s3:
       bucket: "demo-vault-3"

--- a/docs/guides/platforms/gke.md
+++ b/docs/guides/platforms/gke.md
@@ -112,7 +112,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.2.0"
+  version: "1.18.4"
   backend:
     gcs:
       bucket: "demo-vault"

--- a/docs/guides/tenant-isolation/overview.md
+++ b/docs/guides/tenant-isolation/overview.md
@@ -99,9 +99,20 @@ With the gate **on**, you may still pin an engine to a specific (possibly hierar
 OpenBao namespace:
 
 ```yaml
+apiVersion: engine.kubevault.com/v1alpha1
 kind: SecretEngine
+metadata:
+  name: postgres-engine
+  namespace: acme-prod
 spec:
+  vaultRef:
+    name: vault
   namespace: "acme-7f3a/project-x"   # must already exist in OpenBao; only honored when isolateTenants is on
+  postgres:
+    databaseRef:
+      name: postgres
+      namespace: acme-prod
+    pluginName: "postgresql-database-plugin"
 ```
 
 An explicit `spec.namespace` overrides org-derivation and must pre-exist in OpenBao.


### PR DESCRIPTION
Fixes the `Check codespan schema` CI failure on master: https://github.com/kubevault/kubevault/actions/runs/31236555154/job/93049974847

**1. `apiVersion not set`** — the "explicit namespace (advanced)" example in `tenant-isolation/overview.md` was a bare `kind: SecretEngine` / `spec.namespace` snippet with no `apiVersion` or `metadata`. Completed it into a valid `SecretEngine` manifest (same shape used elsewhere in the docs).

**2. `using unknown VaultServer version sigilr-2.6.1.1`** — was a chart-publish timing issue that has since resolved (the `appscode/kubevault-catalog` chart now carries `sigilr-2.6.1.1`, confirmed against the canonical source at [kubevault/installer's raw catalog entry](https://github.com/kubevault/installer/blob/master/catalog/raw/vaultserver/vaultserver-2.6.1-sigilr.yaml)). Left as-is in `tenant-isolation/overview.md` and `deploy-hub-spoke.md`, where it's used deliberately to illustrate a namespace-capable distribution.

**3. Repo-wide cleanup — standardize on `1.18.4`.** That same chart update also *dropped* several ancient EOL Vault versions (`1.2.0`, `1.2.2`, `1.2.3`, `1.7.3`) that ~45 pre-existing example manifests and concept docs across the repo still referenced (generic secret-engine/platform/monitoring guides unrelated to Sigilr or namespaces), which is why `master`'s CI has been failing continuously for weeks. Replaced those `VaultServer.spec.version` references with `1.18.4` (the latest plain Vault OSS entry in the catalog), and updated the handful of "define your own `VaultServerVersion`" example CRs (under `provider/*`, `vault-server`, `policy-management`) to mirror the real `1.18.4` catalog entry's shape (distribution, image, version) instead of stale `vault:1.2.x` images.

I swept the entire `docs/` tree programmatically (cross-checking every `VaultServer`/`VaultServerVersion` `version:` field against the live catalog) — this should be the complete set.